### PR TITLE
errors module should be public to allow for error wrapping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ extern crate serde_derive;
 
 mod util;
 mod client;
-mod errors;
+pub mod errors;
 
 pub mod model;
 


### PR DESCRIPTION
It is poor practice to expose a private struct as a return for a public interface, especially for errors.

It works only on a technicality, as your examples use a match instead of the more accepted method of deriving a new error type with the From trait. With the library currently there is no way to adopt this trait, making it useless for libraries that wish to adapt and return their own errors, or client code that wishes to make use of the try ? operator.