### PR TITLE
Add Exchange Information support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binance"
-version = "0.2.1"
+version = "0.2.2"
 license = "MIT OR Apache-2.0"
 authors = ["Flavio Oliveira <flavio@wisespace.io>"]
 

--- a/src/general.rs
+++ b/src/general.rs
@@ -25,4 +25,13 @@ impl General {
 
         Ok(server_time)
     }
+
+    // Obtain exchange information (rate limits, symbol metadata etc)
+    pub fn exchange_info(&self) -> Result<(ExchangeInformation)> {
+        let data: String = self.client.get("/api/v1/exchangeInfo", "")?;
+
+        let info: ExchangeInformation = from_str(data.as_str()).unwrap();
+
+        Ok(info)
+    }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -6,6 +6,35 @@ pub struct ServerTime {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct ExchangeInformation {
+    pub timezone: String,
+    pub server_time: u64,
+    pub rate_limits: Vec<RateLimit>,
+    pub symbols: Vec<Symbol>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimit {
+    pub rate_limit_type: String,
+    pub interval: String,
+    pub limit: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Symbol {
+    pub symbol: String,
+    pub status: String,
+    pub base_asset: String,
+    pub base_asset_precision: u64,
+    pub quote_asset:String,
+    pub quote_precision: u64,
+    pub order_types: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct AccountInformation {
     pub maker_commission: f32,
     pub taker_commission: f32,


### PR DESCRIPTION
Support for the [exchange information](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#exchange-information) endpoint. This is most useful for obtaining symbol metadata (ie the base vs quote).