### PR TITLE
can deserialize Symbol's filters

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -31,6 +31,33 @@ pub struct Symbol {
     pub quote_asset:String,
     pub quote_precision: u64,
     pub order_types: Vec<String>,
+    pub iceberg_allowed: bool,
+    pub is_spot_trading_allowed: bool,
+    pub is_margin_trading_allowed: bool,
+    pub filters: Vec<Filters>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "filterType")]
+pub enum Filters {
+    #[serde(rename = "PRICE_FILTER")]
+    #[serde(rename_all = "camelCase")]
+    PriceFilter { min_price: String, max_price: String, tick_size: String },
+    #[serde(rename = "PERCENT_PRICE")]
+    #[serde(rename_all = "camelCase")]
+    PercentPrice { multiplier_up: String, multiplier_down: String, avg_price_mins: f64 },
+    #[serde(rename = "LOT_SIZE")]
+    #[serde(rename_all = "camelCase")]
+    LotSize { min_qty: String, max_qty: String, step_size: String },
+    #[serde(rename = "MIN_NOTIONAL")]
+    #[serde(rename_all = "camelCase")]
+    MinNotional { min_notional: String, apply_to_market: bool, avg_price_mins: f64 },
+    #[serde(rename = "ICEBERG_PARTS")]
+    #[serde(rename_all = "camelCase")]
+    IcebergParts { limit: u16 },
+    #[serde(rename = "MAX_NUM_ALGO_ORDERS")]
+    #[serde(rename_all = "camelCase")]
+    MaxNumAlgoOrders { max_num_algo_orders: u16 },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
When requesting exchange informations, a part of the data were not included in the struct which this PR intends to fix.

Now:

```rust
        Symbol {
            symbol: "ZECUSDC",
            status: "TRADING",
            base_asset: "ZEC",
            base_asset_precision: 8,
            quote_asset: "USDC",
            quote_precision: 8,
            order_types: [
                "LIMIT",
                "LIMIT_MAKER",
                "MARKET",
                "STOP_LOSS_LIMIT",
                "TAKE_PROFIT_LIMIT"
            ],
            iceberg_allowed: true,
            is_spot_trading_allowed: true,
            is_margin_trading_allowed: false,
            filters: [
                PriceFilter {
                    min_price: "0.01000000",
                    max_price: "10000000.00000000",
                    tick_size: "0.01000000"
                },
                PercentPrice {
                    multiplier_up: "10",
                    multiplier_down: "0.1",
                    avg_price_mins: 5.0
                },
                LotSize {
                    min_qty: "0.00001000",
                    max_qty: "10000000.00000000",
                    step_size: "0.00001000"
                },
                MinNotional {
                    min_notional: "10.00000000",
                    apply_to_market: true,
                    avg_price_mins: 5.0
                },
                IcebergParts {
                    limit: 10
                },
                MaxNumAlgoOrders {
                    max_num_algo_orders: 5
                }
            ]
        }
```