### PR TITLE
panic api_key fixed

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -124,7 +124,7 @@ impl Client {
         if content_type {
             custon_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/x-www-form-urlencoded"));
         }
-        custon_headers.insert(HeaderName::from_static("X-MBX-APIKEY"), HeaderValue::from_str(self.api_key.as_str())?);
+        custon_headers.insert(HeaderName::from_static("x-mbx-apikey"), HeaderValue::from_str(self.api_key.as_str())?);
 
         Ok(custon_headers)
     }


### PR DESCRIPTION
fix that error 

```
thread 'main' panicked at 'invalid header name'
[...]
   6: http::header::name::parse_hdr::{{closure}}
             at /Users/j/.cargo/registry/src/github.com-1ecc6299db9ec823/http-0.1.16/src/header/name.rs:1660
   7: binance::client::Client::build_headers
             at /Users/j/.cargo/registry/src/github.com-1ecc6299db9ec823/binance-0.3.2/src/client.rs:127
   8: binance::client::Client::new::{{closure}}
             at /Users/j/.cargo/registry/src/github.com-1ecc6299db9ec823/binance-0.3.2/src/client.rs:41
   9: binance::account::Account::limit_buy
             at /Users/j/.cargo/registry/src/github.com-1ecc6299db9ec823/binance-0.3.2/src/account.rs:115
```

since `reqwest` has been updated to 0.9 hence `http 1.1.16` which only allows lowercase header's name cf. https://docs.rs/http/0.1.16/http/header/struct.HeaderName.html#method.from_static