### PR TITLE
handle binance's errors with more precision

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -146,16 +146,19 @@ impl Client {
                 bail!("Unauthorized");
             }
             StatusCode::BAD_REQUEST => {
-                match response.text() {
-                    // if we can read the content, then we show it in order to see Binance's response code & msg
-                    Ok(text) => bail!(format!("Bad Request: {:?} Content: {}", response, text)),
-                    // if not, skip the content
-                    Err(_) => bail!(format!("Bad Request: {:?}", response)),
-                }
+                let error_json: BinanceContentError = response.json()?;
+
+                Err(ErrorKind::BinanceError(error_json.code, error_json.msg, response).into())
             }
             s => {
                 bail!(format!("Received response: {:?}", s));
             }
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BinanceContentError {
+    code: i16,
+    msg: String
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,7 +8,9 @@ error_chain! {
         Error, ErrorKind, ResultExt, Result;
     }
 
-    errors { FooError }
+    errors {
+        BinanceError(code: i16, msg: String, response: reqwest::Response)
+     }
 
     foreign_links {
         ReqError(reqwest::Error);


### PR DESCRIPTION
This allows to be more specific when managing errors and take action accordingly.

```rust
use binance::errors::ErrorKind as BinanceLibErrorKind;

[...]

Err(err) => {
    println!("Can't put an order!");

    match err.0 {
        BinanceLibErrorKind::BinanceError(code, msg, response) => match code {
            -1013_i16 => println!("Filter failure: LOT_SIZE!"),
            -2010_i16 => println!("Funds insufficient! {}", msg),
            _ => println!("Non-catched code {}: {}", code, msg),
        },
        BinanceLibErrorKind::Msg(msg) => {
            println!("Binancelib error msg: {}", msg)
        }
        _ => println!("Other errors: {}.", err.0),
    };
}
```