### PR TITLE
Simplify the websocket implementation to use a single callback

### DIFF
--- a/examples/src/binance_websockets.rs
+++ b/examples/src/binance_websockets.rs
@@ -40,7 +40,7 @@ fn user_stream_websocket() {
     struct WebSocketHandler;
 
     impl UserStreamEventHandler for WebSocketHandler {
-        fn account_update_handler(&self, event: &AccountUpdateEvent) {
+        fn account_update_handler(&mut self, event: &AccountUpdateEvent) {
             for balance in &event.balance {
                 println!(
                     "Asset: {}, free: {}, locked: {}",
@@ -49,7 +49,7 @@ fn user_stream_websocket() {
             }
         }
 
-        fn order_trade_handler(&self, event: &OrderTradeEvent) {
+        fn order_trade_handler(&mut self, event: &OrderTradeEvent) {
             println!(
                 "Symbol: {}, Side: {}, Price: {}, Execution Type: {}",
                 event.symbol, event.side, event.price, event.execution_type
@@ -63,8 +63,10 @@ fn user_stream_websocket() {
     if let Ok(answer) = user_stream.start() {
         let listen_key = answer.listen_key;
 
+        let mut handler = WebSocketHandler {};
         let mut web_socket: WebSockets = WebSockets::new();
-        web_socket.add_user_stream_handler(WebSocketHandler);
+
+        web_socket.add_user_stream_handler(&mut handler);
         web_socket.connect(&listen_key).unwrap(); // check error
         web_socket.event_loop();
     } else {
@@ -76,21 +78,21 @@ fn market_websocket() {
     struct WebSocketHandler;
 
     impl MarketEventHandler for WebSocketHandler {
-        fn aggregated_trades_handler(&self, event: &TradesEvent) {
+        fn aggregated_trades_handler(&mut self, event: &TradesEvent) {
             println!(
                 "Symbol: {}, price: {}, qty: {}",
                 event.symbol, event.price, event.qty
             );
         }
 
-        fn depth_orderbook_handler(&self, event: &DepthOrderBookEvent) {
+        fn depth_orderbook_handler(&mut self, event: &DepthOrderBookEvent) {
             println!(
                 "Symbol: {}, Bids: {:?}, Ask: {:?}",
                 event.symbol, event.bids, event.asks
             );
         }
 
-        fn partial_orderbook_handler(&self, order_book: &OrderBook) {
+        fn partial_orderbook_handler(&mut self, order_book: &OrderBook) {
             println!(
                 "last_update_id: {}, Bids: {:?}, Ask: {:?}",
                 order_book.last_update_id, order_book.bids, order_book.asks
@@ -99,9 +101,10 @@ fn market_websocket() {
     }
 
     let agg_trade: String = format!("{}@aggTrade", "ethbtc");
+    let mut handler = WebSocketHandler {};
     let mut web_socket: WebSockets = WebSockets::new();
 
-    web_socket.add_market_handler(WebSocketHandler);
+    web_socket.add_market_handler(&mut handler);
     web_socket.connect(&agg_trade).unwrap(); // check error
     web_socket.event_loop();
 }
@@ -110,7 +113,7 @@ fn all_trades_websocket() {
     struct WebSocketHandler;
 
     impl DayTickerEventHandler for WebSocketHandler {
-        fn day_ticker_handler(&self, events: &[DayTickerEvent]) {
+        fn day_ticker_handler(&mut self, events: &[DayTickerEvent]) {
             for event in events {
                 println!(
                     "Symbol: {}, price: {}, qty: {}",
@@ -121,9 +124,10 @@ fn all_trades_websocket() {
     }
 
     let agg_trade: String = format!("!ticker@arr");
+    let mut handler = WebSocketHandler {};
     let mut web_socket: WebSockets = WebSockets::new();
 
-    web_socket.add_day_ticker_handler(WebSocketHandler);
+    web_socket.add_day_ticker_handler(&mut handler);
     web_socket.connect(&agg_trade).unwrap(); // check error
     web_socket.event_loop();
 }
@@ -132,7 +136,7 @@ fn kline_websocket() {
     struct WebSocketHandler;
 
     impl KlineEventHandler for WebSocketHandler {
-        fn kline_handler(&self, event: &KlineEvent) {
+        fn kline_handler(&mut self, event: &KlineEvent) {
             println!(
                 "Symbol: {}, high: {}, low: {}",
                 event.kline.symbol, event.kline.low, event.kline.high
@@ -141,9 +145,10 @@ fn kline_websocket() {
     }
 
     let kline: String = format!("{}", "ethbtc@kline_1m");
+    let mut handler = WebSocketHandler {};
     let mut web_socket: WebSockets = WebSockets::new();
 
-    web_socket.add_kline_handler(WebSocketHandler);
+    web_socket.add_kline_handler(&mut handler);
     web_socket.connect(&kline).unwrap(); // check error
     web_socket.event_loop();
 }

--- a/examples/src/binance_websockets.rs
+++ b/examples/src/binance_websockets.rs
@@ -3,8 +3,6 @@ extern crate binance;
 use binance::api::*;
 use binance::userstream::*;
 use binance::websockets::*;
-use binance::model::{AccountUpdateEvent, KlineEvent, OrderTradeEvent,
-                     TradesEvent, DayTickerEvent, OrderBook, DepthOrderBookEvent};
 
 fn main() {
     user_stream();
@@ -37,36 +35,32 @@ fn user_stream() {
 }
 
 fn user_stream_websocket() {
-    struct WebSocketHandler;
-
-    impl UserStreamEventHandler for WebSocketHandler {
-        fn account_update_handler(&mut self, event: &AccountUpdateEvent) {
-            for balance in &event.balance {
-                println!(
-                    "Asset: {}, free: {}, locked: {}",
-                    balance.asset, balance.free, balance.locked
-                );
-            }
-        }
-
-        fn order_trade_handler(&mut self, event: &OrderTradeEvent) {
-            println!(
-                "Symbol: {}, Side: {}, Price: {}, Execution Type: {}",
-                event.symbol, event.side, event.price, event.execution_type
-            );
-        }
-    }
-
     let api_key_user = Some("YOUR_KEY".into());
     let user_stream: UserStream = Binance::new(api_key_user, None);
 
     if let Ok(answer) = user_stream.start() {
         let listen_key = answer.listen_key;
 
-        let mut handler = WebSocketHandler {};
-        let mut web_socket: WebSockets = WebSockets::new();
+        let mut web_socket: WebSockets = WebSockets::new(|event: WebsocketEvent| {
+            match event {
+                WebsocketEvent::AccountUpdate(account_update) => {
+                    for balance in &account_update.balance {
+                        println!(
+                            "Asset: {}, free: {}, locked: {}",
+                            balance.asset, balance.free, balance.locked
+                        );
+                    }
+                },
+                WebsocketEvent::OrderTrade(trade) => {
+                    println!(
+                        "Symbol: {}, Side: {}, Price: {}, Execution Type: {}",
+                        trade.symbol, trade.side, trade.price, trade.execution_type
+                    );
+                },
+                _ => return,
+            }
+        });
 
-        web_socket.add_user_stream_handler(&mut handler);
         web_socket.connect(&listen_key).unwrap(); // check error
         web_socket.event_loop();
     } else {
@@ -75,80 +69,69 @@ fn user_stream_websocket() {
 }
 
 fn market_websocket() {
-    struct WebSocketHandler;
-
-    impl MarketEventHandler for WebSocketHandler {
-        fn aggregated_trades_handler(&mut self, event: &TradesEvent) {
-            println!(
-                "Symbol: {}, price: {}, qty: {}",
-                event.symbol, event.price, event.qty
-            );
-        }
-
-        fn depth_orderbook_handler(&mut self, event: &DepthOrderBookEvent) {
-            println!(
-                "Symbol: {}, Bids: {:?}, Ask: {:?}",
-                event.symbol, event.bids, event.asks
-            );
-        }
-
-        fn partial_orderbook_handler(&mut self, order_book: &OrderBook) {
-            println!(
-                "last_update_id: {}, Bids: {:?}, Ask: {:?}",
-                order_book.last_update_id, order_book.bids, order_book.asks
-            );
-        }
-    }
-
     let agg_trade: String = format!("{}@aggTrade", "ethbtc");
-    let mut handler = WebSocketHandler {};
-    let mut web_socket: WebSockets = WebSockets::new();
+    let mut web_socket: WebSockets = WebSockets::new(|event: WebsocketEvent| {
+        match event {
+            WebsocketEvent::Trade(trade) => {
+                println!(
+                    "Symbol: {}, price: {}, qty: {}",
+                    trade.symbol, trade.price, trade.qty
+                );
+            },
+            WebsocketEvent::DepthOrderBook(depth_order_book) => {
+                println!(
+                    "Symbol: {}, Bids: {:?}, Ask: {:?}",
+                    depth_order_book.symbol, depth_order_book.bids, depth_order_book.asks
+                );
+            },
+            WebsocketEvent::OrderBook(order_book) => {
+                println!(
+                    "last_update_id: {}, Bids: {:?}, Ask: {:?}",
+                    order_book.last_update_id, order_book.bids, order_book.asks
+                );
+            },
+            _ => return,
+        }
+    });
 
-    web_socket.add_market_handler(&mut handler);
     web_socket.connect(&agg_trade).unwrap(); // check error
     web_socket.event_loop();
 }
 
 fn all_trades_websocket() {
-    struct WebSocketHandler;
-
-    impl DayTickerEventHandler for WebSocketHandler {
-        fn day_ticker_handler(&mut self, events: &[DayTickerEvent]) {
-            for event in events {
-                println!(
-                    "Symbol: {}, price: {}, qty: {}",
-                    event.symbol, event.best_bid, event.best_bid_qty
-                );
-            }
-        }
-    }
-
     let agg_trade: String = format!("!ticker@arr");
-    let mut handler = WebSocketHandler {};
-    let mut web_socket: WebSockets = WebSockets::new();
+    let mut web_socket: WebSockets = WebSockets::new(|event: WebsocketEvent| {
+        match event {
+            WebsocketEvent::DayTicker(ticker_events) => {
+                for tick_event in ticker_events {
+                    println!(
+                        "Symbol: {}, price: {}, qty: {}",
+                        tick_event.symbol, tick_event.best_bid, tick_event.best_bid_qty
+                    );
+                }
+            },
+            _ => return,
+        }
+    });
 
-    web_socket.add_day_ticker_handler(&mut handler);
     web_socket.connect(&agg_trade).unwrap(); // check error
     web_socket.event_loop();
 }
 
 fn kline_websocket() {
-    struct WebSocketHandler;
-
-    impl KlineEventHandler for WebSocketHandler {
-        fn kline_handler(&mut self, event: &KlineEvent) {
-            println!(
-                "Symbol: {}, high: {}, low: {}",
-                event.kline.symbol, event.kline.low, event.kline.high
-            );
-        }
-    }
-
     let kline: String = format!("{}", "ethbtc@kline_1m");
-    let mut handler = WebSocketHandler {};
-    let mut web_socket: WebSockets = WebSockets::new();
+    let mut web_socket: WebSockets = WebSockets::new(|event: WebsocketEvent| {
+        match event {
+            WebsocketEvent::Kline(kline_event) => {
+                println!(
+                    "Symbol: {}, high: {}, low: {}",
+                    kline_event.kline.symbol, kline_event.kline.low, kline_event.kline.high
+                );
+            },
+            _ => return,
+        }
+    });
 
-    web_socket.add_kline_handler(&mut handler);
     web_socket.connect(&kline).unwrap(); // check error
     web_socket.event_loop();
 }

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -20,42 +20,29 @@ static PARTIAL_ORDERBOOK : &'static str = "lastUpdateId";
 
 static DAYTICKER: &'static str = "24hrTicker";
 
-pub trait UserStreamEventHandler {
-    fn account_update_handler(&mut self, event: &AccountUpdateEvent);
-    fn order_trade_handler(&mut self, event: &OrderTradeEvent);
+pub enum WebsocketEvent {
+    AccountUpdate(AccountUpdateEvent),
+    OrderTrade(OrderTradeEvent),
+    Trade(TradesEvent),
+    OrderBook(OrderBook),
+    DayTicker(Vec<DayTickerEvent>),
+    Kline(KlineEvent),
+    DepthOrderBook(DepthOrderBookEvent),
 }
 
-pub trait MarketEventHandler {
-    fn aggregated_trades_handler(&mut self, event: &TradesEvent);
-    fn depth_orderbook_handler(&mut self, event: &DepthOrderBookEvent);
-    fn partial_orderbook_handler(&mut self, order_book: &OrderBook);
-}
-
-pub trait DayTickerEventHandler {
-    fn day_ticker_handler(&mut self, event: &[DayTickerEvent]);
-}
-
-pub trait KlineEventHandler {
-    fn kline_handler(&mut self, event: &KlineEvent);
-}
-
-#[derive(Default)]
 pub struct WebSockets<'a> {
     socket: Option<(WebSocket<AutoStream>, Response)>,
-    user_stream_handler: Option<&'a mut UserStreamEventHandler>,
-    market_handler: Option<&'a mut MarketEventHandler>,
-    ticker_handler: Option<&'a mut DayTickerEventHandler>,
-    kline_handler: Option<&'a mut KlineEventHandler>,
+    handler: Box<FnMut(WebsocketEvent) + 'a>,
 }
 
 impl<'a> WebSockets<'a> {
-    pub fn new() -> WebSockets<'a> {
+    pub fn new<Callback>(handler: Callback) -> WebSockets<'a>
+    where
+        Callback: FnMut(WebsocketEvent) + 'a
+    {
         WebSockets {
             socket: None,
-            user_stream_handler: None,
-            market_handler: None,
-            ticker_handler: None,
-            kline_handler: None,
+            handler: Box::new(handler),
         }
     }
 
@@ -74,22 +61,6 @@ impl<'a> WebSockets<'a> {
         }
     }
 
-    pub fn add_user_stream_handler(&mut self, handler: &'a mut UserStreamEventHandler) {
-        self.user_stream_handler = Some(handler);
-    }
-
-    pub fn add_market_handler(&mut self, handler: &'a mut MarketEventHandler) {
-        self.market_handler = Some(handler);
-    }
-
-    pub fn add_day_ticker_handler(&mut self, handler: &'a mut DayTickerEventHandler) {
-        self.ticker_handler = Some(handler);
-    }
-
-    pub fn add_kline_handler(&mut self, handler: &'a mut KlineEventHandler) {
-        self.kline_handler = Some(handler);
-    }
-
     pub fn event_loop(&mut self) {
         loop {
             if let Some(ref mut socket) = self.socket {
@@ -98,45 +69,31 @@ impl<'a> WebSockets<'a> {
                 if msg.find(OUTBOUND_ACCOUNT_INFO) != None {
                     let account_update: AccountUpdateEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref mut h) = self.user_stream_handler {
-                        h.account_update_handler(&account_update);
-                    }
+                    (self.handler)(WebsocketEvent::AccountUpdate(account_update));
                 } else if msg.find(EXECUTION_REPORT) != None {
                     let order_trade: OrderTradeEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref mut h) = self.user_stream_handler {
-                        h.order_trade_handler(&order_trade);
-                    }
+                    (self.handler)(WebsocketEvent::OrderTrade(order_trade));
                 } else if msg.find(AGGREGATED_TRADE) != None {
-                    let trades: TradesEvent = from_str(msg.as_str()).unwrap();
+                    let trade: TradesEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref mut h) = self.market_handler {
-                        h.aggregated_trades_handler(&trades);
-                    }
+                    (self.handler)(WebsocketEvent::Trade(trade));
                 } else if msg.find(DAYTICKER) != None {
                     let trades: Vec<DayTickerEvent> = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref mut h) = self.ticker_handler {
-                        h.day_ticker_handler(&trades);
-                    }
+                    (self.handler)(WebsocketEvent::DayTicker(trades));
                 } else if msg.find(KLINE) != None {
                     let kline: KlineEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref mut h) = self.kline_handler {
-                        h.kline_handler(&kline);
-                    }
+                    (self.handler)(WebsocketEvent::Kline(kline));
                 } else if msg.find(PARTIAL_ORDERBOOK) != None {
                     let partial_orderbook: OrderBook = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref mut h) = self.market_handler {
-                        h.partial_orderbook_handler(&partial_orderbook);
-                    }
+                    (self.handler)(WebsocketEvent::OrderBook(partial_orderbook));
                 } else if msg.find(DEPTH_ORDERBOOK) != None {
                     let depth_orderbook: DepthOrderBookEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref mut h) = self.market_handler {
-                        h.depth_orderbook_handler(&depth_orderbook);
-                    }
+                    (self.handler)(WebsocketEvent::DepthOrderBook(depth_orderbook));
                 }
             }
         }

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -21,35 +21,35 @@ static PARTIAL_ORDERBOOK : &'static str = "lastUpdateId";
 static DAYTICKER: &'static str = "24hrTicker";
 
 pub trait UserStreamEventHandler {
-    fn account_update_handler(&self, event: &AccountUpdateEvent);
-    fn order_trade_handler(&self, event: &OrderTradeEvent);
+    fn account_update_handler(&mut self, event: &AccountUpdateEvent);
+    fn order_trade_handler(&mut self, event: &OrderTradeEvent);
 }
 
 pub trait MarketEventHandler {
-    fn aggregated_trades_handler(&self, event: &TradesEvent);
-    fn depth_orderbook_handler(&self, event: &DepthOrderBookEvent);
-    fn partial_orderbook_handler(&self, order_book: &OrderBook);
+    fn aggregated_trades_handler(&mut self, event: &TradesEvent);
+    fn depth_orderbook_handler(&mut self, event: &DepthOrderBookEvent);
+    fn partial_orderbook_handler(&mut self, order_book: &OrderBook);
 }
 
 pub trait DayTickerEventHandler {
-    fn day_ticker_handler(&self, event: &[DayTickerEvent]);
+    fn day_ticker_handler(&mut self, event: &[DayTickerEvent]);
 }
 
 pub trait KlineEventHandler {
-    fn kline_handler(&self, event: &KlineEvent);
+    fn kline_handler(&mut self, event: &KlineEvent);
 }
 
 #[derive(Default)]
-pub struct WebSockets {
+pub struct WebSockets<'a> {
     socket: Option<(WebSocket<AutoStream>, Response)>,
-    user_stream_handler: Option<Box<UserStreamEventHandler>>,
-    market_handler: Option<Box<MarketEventHandler>>,
-    ticker_handler: Option<Box<DayTickerEventHandler>>,
-    kline_handler: Option<Box<KlineEventHandler>>,
+    user_stream_handler: Option<&'a mut UserStreamEventHandler>,
+    market_handler: Option<&'a mut MarketEventHandler>,
+    ticker_handler: Option<&'a mut DayTickerEventHandler>,
+    kline_handler: Option<&'a mut KlineEventHandler>,
 }
 
-impl WebSockets {
-    pub fn new() -> WebSockets {
+impl<'a> WebSockets<'a> {
+    pub fn new() -> WebSockets<'a> {
         WebSockets {
             socket: None,
             user_stream_handler: None,
@@ -74,32 +74,20 @@ impl WebSockets {
         }
     }
 
-    pub fn add_user_stream_handler<H>(&mut self, handler: H)
-    where
-        H: UserStreamEventHandler + 'static,
-    {
-        self.user_stream_handler = Some(Box::new(handler));
+    pub fn add_user_stream_handler(&mut self, handler: &'a mut UserStreamEventHandler) {
+        self.user_stream_handler = Some(handler);
     }
 
-    pub fn add_market_handler<H>(&mut self, handler: H)
-    where
-        H: MarketEventHandler + 'static,
-    {
-        self.market_handler = Some(Box::new(handler));
+    pub fn add_market_handler(&mut self, handler: &'a mut MarketEventHandler) {
+        self.market_handler = Some(handler);
     }
 
-    pub fn add_day_ticker_handler<H>(&mut self, handler: H)
-    where
-        H: DayTickerEventHandler + 'static,
-    {
-        self.ticker_handler = Some(Box::new(handler));
+    pub fn add_day_ticker_handler(&mut self, handler: &'a mut DayTickerEventHandler) {
+        self.ticker_handler = Some(handler);
     }
 
-    pub fn add_kline_handler<H>(&mut self, handler: H)
-    where
-        H: KlineEventHandler + 'static,
-    {
-        self.kline_handler = Some(Box::new(handler));
+    pub fn add_kline_handler(&mut self, handler: &'a mut KlineEventHandler) {
+        self.kline_handler = Some(handler);
     }
 
     pub fn event_loop(&mut self) {
@@ -110,43 +98,43 @@ impl WebSockets {
                 if msg.find(OUTBOUND_ACCOUNT_INFO) != None {
                     let account_update: AccountUpdateEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref h) = self.user_stream_handler {
+                    if let Some(ref mut h) = self.user_stream_handler {
                         h.account_update_handler(&account_update);
                     }
                 } else if msg.find(EXECUTION_REPORT) != None {
                     let order_trade: OrderTradeEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref h) = self.user_stream_handler {
+                    if let Some(ref mut h) = self.user_stream_handler {
                         h.order_trade_handler(&order_trade);
                     }
                 } else if msg.find(AGGREGATED_TRADE) != None {
                     let trades: TradesEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref h) = self.market_handler {
+                    if let Some(ref mut h) = self.market_handler {
                         h.aggregated_trades_handler(&trades);
                     }
                 } else if msg.find(DAYTICKER) != None {
                     let trades: Vec<DayTickerEvent> = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref h) = self.ticker_handler {
+                    if let Some(ref mut h) = self.ticker_handler {
                         h.day_ticker_handler(&trades);
                     }
                 } else if msg.find(KLINE) != None {
                     let kline: KlineEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref h) = self.kline_handler {
+                    if let Some(ref mut h) = self.kline_handler {
                         h.kline_handler(&kline);
                     }
                 } else if msg.find(PARTIAL_ORDERBOOK) != None {
                     let partial_orderbook: OrderBook = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref h) = self.market_handler {
+                    if let Some(ref mut h) = self.market_handler {
                         h.partial_orderbook_handler(&partial_orderbook);
                     }
                 } else if msg.find(DEPTH_ORDERBOOK) != None {
                     let depth_orderbook: DepthOrderBookEvent = from_str(msg.as_str()).unwrap();
 
-                    if let Some(ref h) = self.market_handler {
+                    if let Some(ref mut h) = self.market_handler {
                         h.depth_orderbook_handler(&depth_orderbook);
                     }
                 }


### PR DESCRIPTION
Instead of using a delegate-style system, this patch moves to use
a callback-event-like system.  This simplifies the code for the
consumer and implementation.  This will allow multi-threaded
systems much easier by giving a single point where a consumer could
plum the calls out of the websocket API up to another thread.