### PR TITLE
Fixing websocket DayTicker failing on unknown trade id's

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -383,9 +383,9 @@ pub struct DayTickerEvent {
 
     #[serde(rename = "C")] pub close_time: u64,
 
-    #[serde(rename = "F")] pub first_trade_id: u64,
+    #[serde(rename = "F")] pub first_trade_id: i64,
 
-    #[serde(rename = "L")] pub last_trade_id: u64,
+    #[serde(rename = "L")] pub last_trade_id: i64,
 
     #[serde(rename = "n")] pub num_trades: u64,
 }


### PR DESCRIPTION
The first_trade_id and last_trade_id are declared as u64, but the binance API sometimes returns -1, causing a panic. This changes those types to i64 to accommodate the possible negative values. 