### PR TITLE
Changing websocket callback to return a Result to allow smarter error…

### DIFF
--- a/examples/binance_websockets.rs
+++ b/examples/binance_websockets.rs
@@ -58,8 +58,10 @@ fn user_stream_websocket() {
                         trade.symbol, trade.side, trade.price, trade.execution_type
                     );
                 },
-                _ => return,
-            }
+                _ => (),
+            };
+
+            Ok(())
         });
 
         web_socket.connect(&listen_key).unwrap(); // check error
@@ -97,8 +99,10 @@ fn market_websocket() {
                     order_book.last_update_id, order_book.bids, order_book.asks
                 );
             },
-            _ => return,
-        }
+            _ => (),
+        };
+
+        Ok(())
     });
 
     web_socket.connect(&agg_trade).unwrap(); // check error
@@ -123,8 +127,10 @@ fn all_trades_websocket() {
                     );
                 }
             },
-            _ => return,
-        }
+            _ => (),
+        };
+
+        Ok(())
     });
 
     web_socket.connect(&agg_trade).unwrap(); // check error
@@ -147,8 +153,10 @@ fn kline_websocket() {
                     kline_event.kline.symbol, kline_event.kline.low, kline_event.kline.high
                 );
             },
-            _ => return,
-        }
+            _ => (),
+        };
+
+        Ok(())
     });
 
     web_socket.connect(&kline).unwrap(); // check error
@@ -176,8 +184,10 @@ fn last_price() {
                     }
                 }
             },
-            _ => return,
-        }
+            _ => (),
+        };
+
+        Ok(())
     });
 
     web_socket.connect(&agg_trade).unwrap(); // check error

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -32,13 +32,13 @@ pub enum WebsocketEvent {
 
 pub struct WebSockets<'a> {
     socket: Option<(WebSocket<AutoStream>, Response)>,
-    handler: Box<FnMut(WebsocketEvent) + 'a>,
+    handler: Box<FnMut(WebsocketEvent) -> Result<()> + 'a>,
 }
 
 impl<'a> WebSockets<'a> {
     pub fn new<Callback>(handler: Callback) -> WebSockets<'a>
     where
-        Callback: FnMut(WebsocketEvent) + 'a
+        Callback: FnMut(WebsocketEvent) -> Result<()> + 'a
     {
         WebSockets {
             socket: None,
@@ -70,25 +70,25 @@ impl<'a> WebSockets<'a> {
                     Message::Text(msg) => {
                         if msg.find(OUTBOUND_ACCOUNT_INFO) != None {
                             let account_update: AccountUpdateEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::AccountUpdate(account_update));
+                            (self.handler)(WebsocketEvent::AccountUpdate(account_update))?;
                         } else if msg.find(EXECUTION_REPORT) != None {
                             let order_trade: OrderTradeEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::OrderTrade(order_trade));
+                            (self.handler)(WebsocketEvent::OrderTrade(order_trade))?;
                         } else if msg.find(AGGREGATED_TRADE) != None {
                             let trade: TradesEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::Trade(trade));
+                            (self.handler)(WebsocketEvent::Trade(trade))?;
                         } else if msg.find(DAYTICKER) != None {
                             let trades: Vec<DayTickerEvent> = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::DayTicker(trades));
+                            (self.handler)(WebsocketEvent::DayTicker(trades))?;
                         } else if msg.find(KLINE) != None {
                             let kline: KlineEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::Kline(kline));
+                            (self.handler)(WebsocketEvent::Kline(kline))?;
                         } else if msg.find(PARTIAL_ORDERBOOK) != None {
                             let partial_orderbook: OrderBook = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::OrderBook(partial_orderbook));
+                            (self.handler)(WebsocketEvent::OrderBook(partial_orderbook))?;
                         } else if msg.find(DEPTH_ORDERBOOK) != None {
                             let depth_orderbook: DepthOrderBookEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::DepthOrderBook(depth_orderbook));
+                            (self.handler)(WebsocketEvent::DepthOrderBook(depth_orderbook))?;
                         }
                     }
                     Message::Ping(_) |


### PR DESCRIPTION
If there's a better/established way of doing this, let me know.

Currently the WebSockets callback doesn't have any return value. The event_loop() returns a Result, but it's limited to errors that might arise strictly from the websockets. Any problems within the callback is limited to a panic. Allowing the callback to return its own Result, that would be bubbled up through to the return value of the event_loop() helps write smarter error handling around websocket events.

This changes the function signature of the callback arg, thus breaking the current API. I've gone and updated the examples, but consumers will not be able to simply upgrade the package version without modifications themselves