### PR TITLE
Implement all remaining orders for the test endpoint

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -123,9 +123,9 @@ impl Account {
         Ok(transaction)
     }
 
-    /// Place a limit buy test order - BUY.
+    /// Place a test limit order - BUY
     ///
-    /// This order is sandboxed: it is validated, but not sent into the matching engine.
+    /// This order is sandboxed: it is validated, but not sent to the matching engine.
     pub fn test_limit_buy<S, F>(&self, symbol: S, qty: F, price: f64) -> Result<()>
         where S: Into<String>, F: Into<f64>
     {
@@ -140,7 +140,7 @@ impl Account {
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
         let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
-        let _: TestTransaction = from_str(data.as_str())?;
+        let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
     }
@@ -165,6 +165,28 @@ impl Account {
         Ok(transaction)
     }
 
+    /// Place a test LIMIT order - SELL
+    ///
+    /// This order is sandboxed: it is validated, but not sent to the matching engine.
+    pub fn test_limit_sell<S, F>(&self, symbol: S, qty: F, price: f64) -> Result<()>
+        where S: Into<String>, F: Into<f64>
+    {
+        let sell: OrderRequest = OrderRequest {
+            symbol: symbol.into(),
+            qty: qty.into(),
+            price: price,
+            order_side: ORDER_SIDE_SELL.to_string(),
+            order_type: ORDER_TYPE_LIMIT.to_string(),
+            time_in_force: TIME_IN_FORCE_GTC.to_string()
+        };
+        let order = self.build_order(sell);
+        let request = build_signed_request(order, self.recv_window)?;
+        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let _: TestResponse = from_str(data.as_str())?;
+
+        Ok(())
+    }
+
     // Place a MARKET order - BUY
     pub fn market_buy<S, F>(&self, symbol: S, qty: F) -> Result<(Transaction)>
         where S: Into<String>, F: Into<f64>
@@ -183,6 +205,28 @@ impl Account {
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
+    }
+
+    /// Place a test MARKET order - BUY
+    ///
+    /// This order is sandboxed: it is validated, but not sent to the matching engine.
+    pub fn test_market_buy<S, F>(&self, symbol: S, qty: F) -> Result<()>
+        where S: Into<String>, F: Into<f64>
+    {
+        let buy: OrderRequest = OrderRequest {
+            symbol: symbol.into(),
+            qty: qty.into(),
+            price: 0.0,
+            order_side: ORDER_SIDE_BUY.to_string(),
+            order_type: ORDER_TYPE_MARKET.to_string(),
+            time_in_force: TIME_IN_FORCE_GTC.to_string()
+        };
+        let order = self.build_order(buy);
+        let request = build_signed_request(order, self.recv_window)?;
+        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let _: TestResponse = from_str(data.as_str())?;
+
+        Ok(())
     }
 
     // Place a MARKET order - SELL
@@ -205,6 +249,28 @@ impl Account {
         Ok(transaction)
     }
 
+    /// Place a test MARKET order - SELL
+    ///
+    /// This order is sandboxed: it is validated, but not sent to the matching engine.
+    pub fn test_market_sell<S, F>(&self, symbol: S, qty: F) -> Result<()>
+        where S: Into<String>, F: Into<f64>
+    {
+        let sell: OrderRequest = OrderRequest {
+            symbol: symbol.into(),
+            qty: qty.into(),
+            price: 0.0,
+            order_side: ORDER_SIDE_SELL.to_string(),
+            order_type: ORDER_TYPE_MARKET.to_string(),
+            time_in_force: TIME_IN_FORCE_GTC.to_string()
+        };
+        let order = self.build_order(sell);
+        let request = build_signed_request(order, self.recv_window)?;
+        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let _: TestResponse = from_str(data.as_str())?;
+
+        Ok(())
+    }
+
     // Check an order's status
     pub fn cancel_order<S>(&self, symbol: S, order_id: u64) -> Result<(OrderCanceled)>
         where S: Into<String>
@@ -218,6 +284,23 @@ impl Account {
         let order_canceled: OrderCanceled = from_str(data.as_str())?;
 
         Ok(order_canceled)
+    }
+
+    /// Place a test cancel order
+    ///
+    /// This order is sandboxed: it is validated, but not sent to the matching engine.
+    pub fn test_cancel_order<S>(&self, symbol: S, order_id: u64) -> Result<()>
+        where S: Into<String>
+    {
+        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("orderId".into(), order_id.to_string());
+
+        let request = build_signed_request(parameters, self.recv_window)?;
+        let data = self.client.delete_signed(API_V3_ORDER_TEST, &request)?;
+        let _: TestResponse = from_str(data.as_str())?;
+
+        Ok(())
     }
 
     // Trade history

--- a/src/account.rs
+++ b/src/account.rs
@@ -103,6 +103,23 @@ impl Account {
         Ok(order)
     }
 
+    /// Place a test status order
+    ///
+    /// This order is sandboxed: it is validated, but not sent to the matching engine.
+    pub fn test_order_status<S>(&self, symbol: S, order_id: u64) -> Result<()>
+        where S: Into<String>
+    {
+        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("orderId".into(), order_id.to_string());
+
+        let request = build_signed_request(parameters, self.recv_window)?;
+        let data = self.client.get_signed(API_V3_ORDER_TEST, &request)?;
+        let _: TestResponse = from_str(data.as_str())?;
+
+        Ok(())
+    }
+
     // Place a LIMIT order - BUY
     pub fn limit_buy<S, F>(&self, symbol: S, qty: F, price: f64) -> Result<(Transaction)>
         where S: Into<String>, F: Into<f64>

--- a/src/model.rs
+++ b/src/model.rs
@@ -126,7 +126,7 @@ pub struct Transaction {
 /// hence this struct has no fields.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct TestTransaction {
+pub struct TestResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Not sure if `Account::order_status` is useful at all, but I have included it for the sake of completeness.