### PR TITLE
Add support for BookTickerEvent

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -358,6 +358,22 @@ pub struct TradesEvent {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct BookTickerEvent {
+    #[serde(rename = "u")] pub update_id: u64,
+
+    #[serde(rename = "s")] pub symbol: String,
+
+    #[serde(rename = "b")] pub best_bid: String,
+
+    #[serde(rename = "B")] pub best_bid_qty: String,
+
+    #[serde(rename = "a")] pub best_ask: String,
+
+    #[serde(rename = "A")] pub best_ask_qty: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct DayTickerEvent {
     #[serde(rename = "e")] pub event_type: String,
 


### PR DESCRIPTION
This should work for both `<symbol>@bookTicker` and `!bookTicker` streams. 

It's not the most elegant solution but seeing as there's no `eventType` in the payload the easiest way was to validate the schema.