### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binance"
-version = "0.10.5"
+version = "0.10.6"
 license = "MIT OR Apache-2.0"
 authors = ["Flavio Oliveira <flavio@wisespace.io>"]
 edition = "2018"
@@ -27,8 +27,11 @@ serde_derive = "1.0"
 error-chain = { version = "0.12", default-features = false }
 ring = "0.16"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
-tungstenite = "0.10"
+tungstenite = "0.11.1"
 url = "2.1"
+
+[features]
+vendored-tls = ["reqwest/native-tls-vendored", "tungstenite/tls-vendored"]
 
 [dev-dependencies]
 csv = "1.0.0"


### PR DESCRIPTION
Specify the `vendored-tls` feature in your Toml file, such as `binance = { version="0.10.6", features=["vendored-tls"]}` to statically link TLS.