### PR TITLE
Endpoint update

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -6,7 +6,7 @@ use crate::futures::market::*;
 use crate::userstream::*;
 use crate::client::*;
 
-static API_HOST: &str = "https://www.binance.com";
+static API_HOST: &str = "https://api.binance.com";
 static FAPI_HOST: &str = "https://fapi.binance.com";
 
 //#[derive(Clone)]


### PR DESCRIPTION
The endpoint is actually `api.binance.com` (https://binance-docs.github.io/apidocs/spot/en/#general-info). It's surprising that `www.binance.com` even works, but just in case Binance deprecates calling the API from `www.binance.com`, let's update it.