### PR TITLE
Add support to combined streams

### DIFF
--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -70,7 +70,7 @@ impl<'a> WebSockets<'a> {
         }
     }
 
-    pub fn connect_multiple_streams(&mut self, endpoints: &Vec<String>) -> Result<()> {
+    pub fn connect_multiple_streams(&mut self, endpoints: &[String]) -> Result<()> {
         let wss: String = format!("{}{}", WEBSOCKET_MULTI_STREAM, endpoints.join("/"));
         let url = Url::parse(&wss)?;
 
@@ -94,7 +94,7 @@ impl<'a> WebSockets<'a> {
         }
     }
 
-    fn handle_msg(&mut self, msg: &String) -> Result<()> {
+    fn handle_msg(&mut self, msg: &str) -> Result<()> {
         let value: serde_json::Value = serde_json::from_str(msg)?;
         if msg.find(STREAM) != None {
             if value["data"] != serde_json::Value::Null {
@@ -108,33 +108,33 @@ impl<'a> WebSockets<'a> {
             && value["a"] != serde_json::Value::Null
             && value["A"] != serde_json::Value::Null
         {
-            let book_ticker: BookTickerEvent = from_str(msg.as_str())?;
+            let book_ticker: BookTickerEvent = from_str(msg)?;
             (self.handler)(WebsocketEvent::BookTicker(book_ticker))?;
         } else if msg.find(OUTBOUND_ACCOUNT_INFO) != None {
-            let account_update: AccountUpdateEvent = from_str(msg.as_str())?;
+            let account_update: AccountUpdateEvent = from_str(msg)?;
             (self.handler)(WebsocketEvent::AccountUpdate(account_update))?;
         } else if msg.find(EXECUTION_REPORT) != None {
-            let order_trade: OrderTradeEvent = from_str(msg.as_str())?;
+            let order_trade: OrderTradeEvent = from_str(msg)?;
             (self.handler)(WebsocketEvent::OrderTrade(order_trade))?;
         } else if msg.find(AGGREGATED_TRADE) != None {
-            let trade: TradesEvent = from_str(msg.as_str())?;
+            let trade: TradesEvent = from_str(msg)?;
             (self.handler)(WebsocketEvent::Trade(trade))?;
         } else if msg.find(DAYTICKER) != None {
             if self.subscription == "!ticker@arr" {
-                let trades: Vec<DayTickerEvent> = from_str(msg.as_str())?;
+                let trades: Vec<DayTickerEvent> = from_str(msg)?;
                 (self.handler)(WebsocketEvent::DayTickerAll(trades))?;
             } else {
-                let trades: DayTickerEvent = from_str(msg.as_str())?;
+                let trades: DayTickerEvent = from_str(msg)?;
                 (self.handler)(WebsocketEvent::DayTicker(trades))?;
             }
         } else if msg.find(KLINE) != None {
-            let kline: KlineEvent = from_str(msg.as_str())?;
+            let kline: KlineEvent = from_str(msg)?;
             (self.handler)(WebsocketEvent::Kline(kline))?;
         } else if msg.find(PARTIAL_ORDERBOOK) != None {
-            let partial_orderbook: OrderBook = from_str(msg.as_str())?;
+            let partial_orderbook: OrderBook = from_str(msg)?;
             (self.handler)(WebsocketEvent::OrderBook(partial_orderbook))?;
         } else if msg.find(DEPTH_ORDERBOOK) != None {
-            let depth_orderbook: DepthOrderBookEvent = from_str(msg.as_str())?;
+            let depth_orderbook: DepthOrderBookEvent = from_str(msg)?;
             (self.handler)(WebsocketEvent::DepthOrderBook(depth_orderbook))?;
         }
         Ok(())

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -10,6 +10,7 @@ use tungstenite::client::AutoStream;
 use tungstenite::handshake::client::Response;
 
 static WEBSOCKET_URL: &str = "wss://stream.binance.com:9443/ws/";
+static WEBSOCKET_MULTI_STREAM: &'static str = "wss://stream.binance.com:9443/stream?streams="; // <streamName1>/<streamName2>/<streamName3>
 
 static OUTBOUND_ACCOUNT_INFO: &str = "outboundAccountInfo";
 static EXECUTION_REPORT: &str = "executionReport";
@@ -18,6 +19,7 @@ static KLINE: &str = "kline";
 static AGGREGATED_TRADE: &str = "aggTrade";
 static DEPTH_ORDERBOOK: &str = "depthUpdate";
 static PARTIAL_ORDERBOOK: &str = "lastUpdateId";
+static STREAM: &'static str = "stream";
 
 static DAYTICKER: &str = "24hrTicker";
 
@@ -37,7 +39,7 @@ pub enum WebsocketEvent {
 pub struct WebSockets<'a> {
     pub socket: Option<(WebSocket<AutoStream>, Response)>,
     handler: Box<dyn FnMut(WebsocketEvent) -> Result<()> + 'a>,
-    subscription: &'a str
+    subscription: &'a str,
 }
 
 impl<'a> WebSockets<'a> {
@@ -68,6 +70,21 @@ impl<'a> WebSockets<'a> {
         }
     }
 
+    pub fn connect_multiple_streams(&mut self, endpoints: &Vec<String>) -> Result<()> {
+        let wss: String = format!("{}{}", WEBSOCKET_MULTI_STREAM, endpoints.join("/"));
+        let url = Url::parse(&wss)?;
+
+        match connect(url) {
+            Ok(answer) => {
+                self.socket = Some(answer);
+                Ok(())
+            }
+            Err(e) => {
+                bail!(format!("Error during handshake {}", e));
+            }
+        }
+    }
+
     pub fn disconnect(&mut self) -> Result<()> {
         if let Some(ref mut socket) = self.socket {
             socket.0.close(None)?;
@@ -77,6 +94,53 @@ impl<'a> WebSockets<'a> {
         }
     }
 
+    fn handle_msg(&mut self, msg: &String, value: &serde_json::Value) -> Result<()> {
+        if value["u"] != serde_json::Value::Null
+            && value["s"] != serde_json::Value::Null
+            && value["b"] != serde_json::Value::Null
+            && value["B"] != serde_json::Value::Null
+            && value["a"] != serde_json::Value::Null
+            && value["A"] != serde_json::Value::Null
+        {
+            let book_ticker: BookTickerEvent = from_str(msg.as_str())?;
+            (self.handler)(WebsocketEvent::BookTicker(book_ticker))?;
+        } else if msg.find(OUTBOUND_ACCOUNT_INFO) != None {
+            let account_update: AccountUpdateEvent = from_str(msg.as_str())?;
+            (self.handler)(WebsocketEvent::AccountUpdate(account_update))?;
+        } else if msg.find(EXECUTION_REPORT) != None {
+            let order_trade: OrderTradeEvent = from_str(msg.as_str())?;
+            (self.handler)(WebsocketEvent::OrderTrade(order_trade))?;
+        } else if msg.find(AGGREGATED_TRADE) != None {
+            let trade: TradesEvent = from_str(msg.as_str())?;
+            (self.handler)(WebsocketEvent::Trade(trade))?;
+        } else if msg.find(DAYTICKER) != None {
+            if self.subscription == "!ticker@arr" {
+                let trades: Vec<DayTickerEvent> = from_str(msg.as_str())?;
+                (self.handler)(WebsocketEvent::DayTickerAll(trades))?;
+            } else {
+                let trades: DayTickerEvent = from_str(msg.as_str())?;
+                (self.handler)(WebsocketEvent::DayTicker(trades))?;
+            }
+        } else if msg.find(KLINE) != None {
+            let kline: KlineEvent = from_str(msg.as_str())?;
+            (self.handler)(WebsocketEvent::Kline(kline))?;
+        } else if msg.find(PARTIAL_ORDERBOOK) != None {
+            let partial_orderbook: OrderBook = from_str(msg.as_str())?;
+            (self.handler)(WebsocketEvent::OrderBook(partial_orderbook))?;
+        } else if msg.find(DEPTH_ORDERBOOK) != None {
+            let depth_orderbook: DepthOrderBookEvent = from_str(msg.as_str())?;
+            (self.handler)(WebsocketEvent::DepthOrderBook(depth_orderbook))?;
+        } else if msg.find(STREAM) != None {
+            let i_msg = msg.find("\"data\":");
+            let i_end = msg.rfind("}");
+            if let (Some(i_msg_), Some(i_end_)) = (i_msg, i_end) {
+                let sub_string = msg.chars().skip(i_msg_).take(i_end_ - i_msg_ - 1).collect();
+                self.handle_msg(&sub_string, &value).unwrap();
+            };
+        }
+        Ok(())
+    }
+
     pub fn event_loop(&mut self, running: &AtomicBool) -> Result<()> {
         while running.load(Ordering::Relaxed) {
             if let Some(ref mut socket) = self.socket {
@@ -84,49 +148,13 @@ impl<'a> WebSockets<'a> {
                 let value: serde_json::Value = serde_json::from_str(message.to_text()?)?;
 
                 match message {
-                    Message::Text(msg) => {
-                        if value["u"] != serde_json::Value::Null &&
-                            value["s"] != serde_json::Value::Null &&
-                            value["b"] != serde_json::Value::Null &&
-                            value["B"] != serde_json::Value::Null &&
-                            value["a"] != serde_json::Value::Null &&
-                            value["A"] != serde_json::Value::Null
-                        {
-                            let book_ticker: BookTickerEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::BookTicker(book_ticker))?;
-                        } else if msg.find(OUTBOUND_ACCOUNT_INFO) != None {
-                            let account_update: AccountUpdateEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::AccountUpdate(account_update))?;
-                        } else if msg.find(EXECUTION_REPORT) != None {
-                            let order_trade: OrderTradeEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::OrderTrade(order_trade))?;
-                        } else if msg.find(AGGREGATED_TRADE) != None {
-                            let trade: TradesEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::Trade(trade))?;
-                        } else if msg.find(DAYTICKER) != None {
-                            if self.subscription == "!ticker@arr" {
-                                let trades: Vec<DayTickerEvent> = from_str(msg.as_str())?;
-                                (self.handler)(WebsocketEvent::DayTickerAll(trades))?;
-                            } else {
-                                let trades: DayTickerEvent = from_str(msg.as_str())?;
-                                (self.handler)(WebsocketEvent::DayTicker(trades))?;
-                            }
-                        } else if msg.find(KLINE) != None {
-                            let kline: KlineEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::Kline(kline))?;
-                        } else if msg.find(PARTIAL_ORDERBOOK) != None {
-                            let partial_orderbook: OrderBook = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::OrderBook(partial_orderbook))?;
-                        } else if msg.find(DEPTH_ORDERBOOK) != None {
-                            let depth_orderbook: DepthOrderBookEvent = from_str(msg.as_str())?;
-                            (self.handler)(WebsocketEvent::DepthOrderBook(depth_orderbook))?;
-                        }
-                    }
-                    Message::Ping(_) | Message::Pong(_) | Message::Binary(_) => {}
+                    Message::Text(msg) => self.handle_msg(&msg, &value),
+                    Message::Ping(_) | Message::Pong(_) | Message::Binary(_) => Ok(()),
                     Message::Close(e) => {
                         bail!(format!("Disconnected {:?}", e));
                     }
                 }
+                .unwrap();
             }
         }
         Ok(())


### PR DESCRIPTION
Initially implemented on https://github.com/0x53A/binance-rs/commit/ed9342f5770d62a890829fa83178af57d5be09b0 but then adapted to fit current version. Works fine on [gabriel-milan/btrader](https://github.com/gabriel-milan/btrader).

Refers to https://github.com/wisespace-io/binance-rs/issues/15 and https://github.com/wisespace-io/binance-rs/issues/48 (and probably https://github.com/wisespace-io/binance-rs/issues/56).

https://github.com/wisespace-io/binance-rs/issues/15 mentions that it works just by using the current implementation, but I had few issues while trying with around 780 symbols. Official API reference: https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#general-wss-information