### PR TITLE
singular-trade

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -155,11 +155,11 @@ pub struct Transaction {
     pub transact_time: u64,
     #[serde(with = "string_or_float")]
     pub price: f64,
-    #[serde(with = "string_or_float")]    
+    #[serde(with = "string_or_float")]
     pub orig_qty: f64,
-    #[serde(with = "string_or_float")]    
+    #[serde(with = "string_or_float")]
     pub executed_qty: f64,
-    #[serde(with = "string_or_float")]    
+    #[serde(with = "string_or_float")]
     pub cummulative_quote_qty: f64,
     pub status: String,
     pub time_in_force: String,
@@ -172,9 +172,9 @@ pub struct Transaction {
 pub struct FillInfo {
     #[serde(with = "string_or_float")]
     pub price: f64,
-    #[serde(with = "string_or_float")]    
+    #[serde(with = "string_or_float")]
     pub qty: f64,
-    #[serde(with = "string_or_float")]    
+    #[serde(with = "string_or_float")]
     pub commission: f64,
     pub commission_asset: String,
     pub trade_id: Option<u64>,
@@ -444,9 +444,16 @@ pub struct OrderTradeEvent {
     pub m_ignore: bool,
 }
 
+/// The Aggregate Trade Streams push trade information that is aggregated for a single taker order.
+///
+/// Stream Name: \<symbol\>@aggTrade
+///
+/// Update Speed: Real-time
+///
+/// https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#aggregate-trade-streams
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct TradesEvent {
+pub struct AggrTradesEvent {
     #[serde(rename = "e")]
     pub event_type: String,
 
@@ -470,6 +477,50 @@ pub struct TradesEvent {
 
     #[serde(rename = "l")]
     pub last_break_trade_id: u64,
+
+    #[serde(rename = "T")]
+    pub trade_order_time: u64,
+
+    #[serde(rename = "m")]
+    pub is_buyer_maker: bool,
+
+    #[serde(skip, rename = "M")]
+    pub m_ignore: bool,
+}
+
+/// The Trade Streams push raw trade information; each trade has a unique buyer and seller.
+///
+/// Stream Name: \<symbol\>@trade
+///
+/// Update Speed: Real-time
+///
+/// https://github.com/binance/binance-spot-api-docs/blob/master/web-socket-streams.md#trade-streams
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TradeEvent {
+    #[serde(rename = "e")]
+    pub event_type: String,
+
+    #[serde(rename = "E")]
+    pub event_time: u64,
+
+    #[serde(rename = "s")]
+    pub symbol: String,
+
+    #[serde(rename = "t")]
+    pub trade_id: u64,
+
+    #[serde(rename = "p")]
+    pub price: String,
+
+    #[serde(rename = "q")]
+    pub qty: String,
+
+    #[serde(rename = "b")]
+    pub buyer_order_id: u64,
+
+    #[serde(rename = "a")]
+    pub seller_order_id: u64,
 
     #[serde(rename = "T")]
     pub trade_order_time: u64,

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -17,6 +17,7 @@ static EXECUTION_REPORT: &str = "executionReport";
 
 static KLINE: &str = "kline";
 static AGGREGATED_TRADE: &str = "aggTrade";
+static TRADE: &str = "trade";
 static DEPTH_ORDERBOOK: &str = "depthUpdate";
 static PARTIAL_ORDERBOOK: &str = "lastUpdateId";
 static STREAM: &str = "stream";
@@ -27,7 +28,8 @@ static DAYTICKER: &str = "24hrTicker";
 pub enum WebsocketEvent {
     AccountUpdate(AccountUpdateEvent),
     OrderTrade(OrderTradeEvent),
-    Trade(TradesEvent),
+    AggrTrades(AggrTradesEvent),
+    Trade(TradeEvent),
     OrderBook(OrderBook),
     DayTicker(DayTickerEvent),
     DayTickerAll(Vec<DayTickerEvent>),
@@ -117,7 +119,10 @@ impl<'a> WebSockets<'a> {
             let order_trade: OrderTradeEvent = from_str(msg)?;
             (self.handler)(WebsocketEvent::OrderTrade(order_trade))?;
         } else if msg.find(AGGREGATED_TRADE) != None {
-            let trade: TradesEvent = from_str(msg)?;
+            let trade: AggrTradesEvent = from_str(msg)?;
+            (self.handler)(WebsocketEvent::AggrTrades(trade))?;
+        } else if msg.find(TRADE) != None {
+            let trade: TradeEvent = from_str(msg)?;
             (self.handler)(WebsocketEvent::Trade(trade))?;
         } else if msg.find(DAYTICKER) != None {
             if self.subscription == "!ticker@arr" {


### PR DESCRIPTION
Added the actual '<symbol>@trade' support. Copied docs for AggrTrade and Trade.
Renamed TradesEvent into AggrTradesEvent which is breaking change but makes it more readable.