### PR TITLE
[work in progress] Creation of config options

### DIFF
--- a/examples/binance_endpoints.rs
+++ b/examples/binance_endpoints.rs
@@ -1,17 +1,27 @@
 use binance::api::*;
+use binance::config::*;
 use binance::general::*;
 use binance::account::*;
 use binance::market::*;
 use binance::errors::ErrorKind as BinanceLibErrorKind;
 
 fn main() {
-    general();
+    general(false);
+    general(true);
     //account();
     //market_data();
 }
 
-fn general() {
-    let general: General = Binance::new(None, None);
+fn general(use_testnet: bool) {
+    let general: General = if use_testnet {
+        let config = Config {
+            rest_api_endpoint: "https://api.binance.com".into(),
+            ws_endpoint: "wss://stream.binance.com:9443/ws/".into(),
+        };
+        Binance::new_with_config(None, None, &config)
+    } else {
+        Binance::new(None, None)
+    };
 
     let ping = general.ping();
     match ping {

--- a/examples/binance_endpoints.rs
+++ b/examples/binance_endpoints.rs
@@ -8,16 +8,16 @@ use binance::errors::ErrorKind as BinanceLibErrorKind;
 fn main() {
     general(false);
     general(true);
+
+    // those examples need an API key. change those lines locally
+    // and uncomment those (and do not commit your api key :))
     //account();
     //market_data();
 }
 
 fn general(use_testnet: bool) {
     let general: General = if use_testnet {
-        let config = Config {
-            rest_api_endpoint: "https://api.binance.com".into(),
-            ws_endpoint: "wss://stream.binance.com:9443/ws/".into(),
-        };
+        let config = Config::default().set_rest_api_endpoint("https://testnet.binance.vision".to_string());
         Binance::new_with_config(None, None, &config)
     } else {
         Binance::new(None, None)
@@ -57,6 +57,7 @@ fn general(use_testnet: bool) {
     }
 }
 
+#[allow(dead_code)]
 fn account() {
     let api_key = Some("YOUR_API_KEY".into());
     let secret_key = Some("YOUR_SECRET_KEY".into());
@@ -115,6 +116,7 @@ fn account() {
     }
 }
 
+#[allow(dead_code)]
 fn market_data() {
     let market: Market = Binance::new(None, None);
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,5 @@
 use crate::account::*;
+use crate::config::*;
 use crate::market::*;
 use crate::general::*;
 use crate::futures::general::*;
@@ -12,6 +13,9 @@ static FAPI_HOST: &str = "https://fapi.binance.com";
 //#[derive(Clone)]
 pub trait Binance {
     fn new(api_key: Option<String>, secret_key: Option<String>) -> Self;
+    fn new_with_config(
+        api_key: Option<String>, secret_key: Option<String>, config: &Config,
+    ) -> Self;
 }
 
 impl Binance for General {
@@ -20,12 +24,29 @@ impl Binance for General {
             client: Client::new(api_key, secret_key, API_HOST.to_string()),
         }
     }
+
+    fn new_with_config(
+        api_key: Option<String>, secret_key: Option<String>, config: &Config,
+    ) -> General {
+        General {
+            client: Client::new(api_key, secret_key, config.rest_api_endpoint.clone()),
+        }
+    }
 }
 
 impl Binance for Account {
     fn new(api_key: Option<String>, secret_key: Option<String>) -> Account {
         Account {
             client: Client::new(api_key, secret_key, API_HOST.to_string()),
+            recv_window: 5000,
+        }
+    }
+
+    fn new_with_config(
+        api_key: Option<String>, secret_key: Option<String>, config: &Config,
+    ) -> Account {
+        Account {
+            client: Client::new(api_key, secret_key, config.rest_api_endpoint.clone()),
             recv_window: 5000,
         }
     }
@@ -38,12 +59,30 @@ impl Binance for Market {
             recv_window: 5000,
         }
     }
+
+    fn new_with_config(
+        api_key: Option<String>, secret_key: Option<String>, config: &Config,
+    ) -> Market {
+        Market {
+            client: Client::new(api_key, secret_key, config.rest_api_endpoint.clone()),
+            recv_window: 5000,
+        }
+    }
 }
 
 impl Binance for UserStream {
     fn new(api_key: Option<String>, secret_key: Option<String>) -> UserStream {
         UserStream {
             client: Client::new(api_key, secret_key, API_HOST.to_string()),
+            recv_window: 5000,
+        }
+    }
+
+    fn new_with_config(
+        api_key: Option<String>, secret_key: Option<String>, config: &Config,
+    ) -> UserStream {
+        UserStream {
+            client: Client::new(api_key, secret_key, config.rest_api_endpoint.clone()),
             recv_window: 5000,
         }
     }
@@ -59,12 +98,29 @@ impl Binance for FuturesGeneral {
             client: Client::new(api_key, secret_key, FAPI_HOST.to_string()),
         }
     }
+
+    fn new_with_config(
+        api_key: Option<String>, secret_key: Option<String>, config: &Config,
+    ) -> FuturesGeneral {
+        FuturesGeneral {
+            client: Client::new(api_key, secret_key, config.rest_api_endpoint.clone()),
+        }
+    }
 }
 
 impl Binance for FuturesMarket {
     fn new(api_key: Option<String>, secret_key: Option<String>) -> FuturesMarket {
         FuturesMarket {
             client: Client::new(api_key, secret_key, FAPI_HOST.to_string()),
+            recv_window: 5000,
+        }
+    }
+
+    fn new_with_config(
+        api_key: Option<String>, secret_key: Option<String>, config: &Config,
+    ) -> FuturesMarket {
+        FuturesMarket {
+            client: Client::new(api_key, secret_key, config.rest_api_endpoint.clone()),
             recv_window: 5000,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,25 @@
+#[derive(Clone, Debug, PartialEq)]
+pub struct Config {
+    pub rest_api_endpoint: String,
+    pub ws_endpoint: String,
+}
+
+#[allow(dead_code)]
+impl Config {
+    pub fn default() -> Config {
+        Config {
+            rest_api_endpoint: "https://api.binance.com".into(),
+            ws_endpoint: "wss://stream.binance.com:9443/ws/".into()
+        }
+    }
+
+    pub fn set_rest_api_endpoint(mut self, rest_api_endpoint: String) -> Self {
+        self.rest_api_endpoint = rest_api_endpoint;
+        self
+    }
+
+    pub fn set_ws_endpoint(mut self, ws_endpoint: String) -> Self {
+        self.ws_endpoint = ws_endpoint;
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod model;
 
 pub mod account;
 pub mod api;
+pub mod config;
 pub mod general;
 pub mod market;
 pub mod userstream;

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -1,5 +1,6 @@
-use crate::model::*;
 use crate::errors::*;
+use crate::config::*;
+use crate::model::*;
 use url::Url;
 use serde_json::from_str;
 
@@ -59,6 +60,22 @@ impl<'a> WebSockets<'a> {
     pub fn connect(&mut self, subscription: &'a str) -> Result<()> {
         self.subscription = subscription;
         let wss: String = format!("{}{}", WEBSOCKET_URL, subscription);
+        let url = Url::parse(&wss)?;
+
+        match connect(url) {
+            Ok(answer) => {
+                self.socket = Some(answer);
+                Ok(())
+            }
+            Err(e) => {
+                bail!(format!("Error during handshake {}", e));
+            }
+        }
+    }
+
+    pub fn connect_with_config(&mut self, subscription: &'a str, config: &'a Config) -> Result<()> {
+        self.subscription = subscription;
+        let wss: String = format!("{}{}", &config.ws_endpoint, subscription);
         let url = Url::parse(&wss)?;
 
         match connect(url) {


### PR DESCRIPTION
To solve https://github.com/wisespace-io/binance-rs/issues/61 and https://github.com/wisespace-io/binance-rs/issues/74, we need a `Config` struct. This was my first attempt to make one.

I made a new `new_with_config` function in the `Binance` trait. We could also change the signature of the existing `new` function, but that would be an API breaking change. @wisespace-io: Please let me know what you think is best.

This PR was for early feedback, what I want to do for sure is:
- add binance futures to the config
- make make easy convenience methods to switch from default to binance-us or testnet
- use `&str` types instead of `String`, but I need to learn a bit more Rust to do this.

All feedback welcome!