### PR TITLE
New function "get_all_24h_price_stats"

### DIFF
--- a/src/market.rs
+++ b/src/market.rs
@@ -115,7 +115,7 @@ impl Market {
     }
 
     // 24hr ticker price change statistics for all symbols
-    pub fn get_24h_price_stats_all(&self) -> Result<Vec<PriceStats>> {
+    pub fn get_all_24h_price_stats(&self) -> Result<Vec<PriceStats>> {
         let data = self.client.get("/api/v3/ticker/24hr", "")?;
 
         let stats: Vec<PriceStats> = from_str(data.as_str())?;

--- a/src/market.rs
+++ b/src/market.rs
@@ -114,6 +114,15 @@ impl Market {
         Ok(stats)
     }
 
+    // 24hr ticker price change statistics for all symbols
+    pub fn get_24h_price_stats_all(&self) -> Result<Vec<PriceStats>> {
+        let data = self.client.get("/api/v3/ticker/24hr", "")?;
+
+        let stats: Vec<PriceStats> = from_str(data.as_str())?;
+
+        Ok(stats)
+    }
+
     // Returns up to 'limit' klines for given symbol and interval ("1m", "5m", ...)
     // https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#klinecandlestick-data
     pub fn get_klines<S1, S2, S3, S4, S5>(

--- a/src/model.rs
+++ b/src/model.rs
@@ -294,6 +294,7 @@ pub struct TradeHistory {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PriceStats {
+    pub symbol: String,
     pub price_change: String,
     pub price_change_percent: String,
     pub weighted_avg_price: String,

--- a/src/model.rs
+++ b/src/model.rs
@@ -316,8 +316,8 @@ pub struct PriceStats {
     pub volume: f64,
     pub open_time: u64,
     pub close_time: u64,
-    pub first_id: u64,
-    pub last_id: u64,
+    pub first_id: i64,
+    pub last_id: i64,
     pub count: u64,
 }
 


### PR DESCRIPTION
The Binance API makes the symbol parameter optional in 24hr ticker price statistics (https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md#24hr-ticker-price-change-statistics), to enable downloading of all symbol statistics in one go. This is what this function provides.