### PR TITLE
Add Stop Limit orders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binance"
-version = "0.12.3"
+version = "0.12.4"
 license = "MIT OR Apache-2.0"
 authors = ["Flavio Oliveira <flavio@wisespace.io>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,18 +20,18 @@ name = "binance"
 path = "src/lib.rs"
 
 [dependencies]
-hex = "0.4"
+hex = "0.4.3"
 hmac = "0.10.1"
-sha2 = "0.9"
-serde = { version = "1.0.118", features = ["derive"] }
-serde_json = "1.0"
+sha2 = "0.9.3"
+serde = { version = "1.0.125", features = ["derive"] }
+serde_json = "1.0.64"
 error-chain = { version = "0.12.4", default-features = false }
 reqwest = { version = "0.10.9", features = ["blocking", "json"] }
 tungstenite = "0.11.1"
-url = "2.2.0"
+url = "2.2.1"
 
 [features]
 vendored-tls = ["reqwest/native-tls-vendored", "tungstenite/tls-vendored"]
 
 [dev-dependencies]
-csv ="1.1.5"
+csv ="1.1.6"

--- a/src/account.rs
+++ b/src/account.rs
@@ -4,18 +4,8 @@ use crate::client::*;
 use crate::errors::*;
 use std::collections::BTreeMap;
 use serde_json::from_str;
-
-// static ORDER_TYPE_LIMIT: &str = "LIMIT";
-// static ORDER_TYPE_MARKET: &str = "MARKET";
-// static ORDER_SIDE_BUY: &str = "BUY";
-// static ORDER_SIDE_SELL: &str = "SELL";
-
-static API_V3_ORDER: &str = "/api/v3/order";
-
-/// Endpoint for test orders.
-///
-/// Orders issued to this endpoint are validated, but not sent into the matching engine.
-static API_V3_ORDER_TEST: &str = "/api/v3/order/test";
+use crate::api::API;
+use crate::api::Spot;
 
 #[derive(Clone)]
 pub struct Account {
@@ -94,7 +84,7 @@ impl Account {
         let parameters: BTreeMap<String, String> = BTreeMap::new();
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed("/api/v3/account", &request)?;
+        let data = self.client.get_signed(API::Spot(Spot::Account), &request)?;
         let account_info: AccountInformation = from_str(data.as_str())?;
 
         Ok(account_info)
@@ -128,7 +118,7 @@ impl Account {
         parameters.insert("symbol".into(), symbol.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed("/api/v3/openOrders", &request)?;
+        let data = self.client.get_signed(API::Spot(Spot::OpenOrders), &request)?;
         let order: Vec<Order> = from_str(data.as_str())?;
 
         Ok(order)
@@ -139,7 +129,7 @@ impl Account {
         let parameters: BTreeMap<String, String> = BTreeMap::new();
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed("/api/v3/openOrders", &request)?;
+        let data = self.client.get_signed(API::Spot(Spot::OpenOrders), &request)?;
         let order: Vec<Order> = from_str(data.as_str())?;
 
         Ok(order)
@@ -153,7 +143,7 @@ impl Account {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
         parameters.insert("symbol".into(), symbol.into());
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.delete_signed("/api/v3/openOrders", &request)?;
+        let data = self.client.delete_signed(API::Spot(Spot::OpenOrders), &request)?;
         let order: Vec<OrderCanceled> = from_str(data.as_str())?;
 
         Ok(order)
@@ -169,7 +159,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed(API_V3_ORDER, &request)?;
+        let data = self.client.get_signed(API::Spot(Spot::Order), &request)?;
         let order: Order = from_str(data.as_str())?;
 
         Ok(order)
@@ -187,7 +177,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.get_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -210,7 +200,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
@@ -235,7 +225,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -258,7 +248,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
@@ -283,7 +273,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -306,7 +296,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
@@ -331,7 +321,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -355,7 +345,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
@@ -381,7 +371,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -404,7 +394,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
@@ -429,7 +419,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -453,7 +443,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
@@ -479,7 +469,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -509,7 +499,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
@@ -541,7 +531,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -571,7 +561,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
@@ -603,7 +593,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -635,7 +625,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
@@ -668,7 +658,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -684,7 +674,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.delete_signed(API_V3_ORDER, &request)?;
+        let data = self.client.delete_signed(API::Spot(Spot::Order), &request)?;
         let order_canceled: OrderCanceled = from_str(data.as_str())?;
 
         Ok(order_canceled)
@@ -702,7 +692,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.delete_signed(API_V3_ORDER_TEST, &request)?;
+        let data = self.client.delete_signed(API::Spot(Spot::OrderTest), &request)?;
         let _: TestResponse = from_str(data.as_str())?;
 
         Ok(())
@@ -717,7 +707,7 @@ impl Account {
         parameters.insert("symbol".into(), symbol.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed("/api/v3/myTrades", &request)?;
+        let data = self.client.get_signed(API::Spot(Spot::MyTrades), &request)?;
         let trade_history: Vec<TradeHistory> = from_str(data.as_str())?;
 
         Ok(trade_history)

--- a/src/account.rs
+++ b/src/account.rs
@@ -515,6 +515,38 @@ impl Account {
         Ok(transaction)
     }
 
+    /// Place a test stop limit sell order
+    ///
+    /// This order is sandboxed: it is validated, but not sent to the matching engine.
+    pub fn test_stop_limit_buy_order<S, F>(
+        &self,
+        symbol: S,
+        qty: F,
+        price: f64,
+        stop_price: f64,
+        time_in_force: TimeInForce,
+    ) -> Result<()>
+    where
+        S: Into<String>,
+        F: Into<f64>,
+    {
+        let sell: OrderRequest = OrderRequest {
+            symbol: symbol.into(),
+            qty: qty.into(),
+            price,
+            stop_price: Some(stop_price),
+            order_side: OrderSide::Sell,
+            order_type: OrderType::StopLossLimit,
+            time_in_force: time_in_force,
+        };
+        let order = self.build_order(sell);
+        let request = build_signed_request(order, self.recv_window)?;
+        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let _: TestResponse = from_str(data.as_str())?;
+
+        Ok(())
+    }
+
     /// Place a stop limit buy order
     pub fn stop_limit_buy_order<S, F>(
         &self,
@@ -543,6 +575,38 @@ impl Account {
         let transaction: Transaction = from_str(data.as_str())?;
 
         Ok(transaction)
+    }
+
+    /// Place a test stop limit buy order
+    ///
+    /// This order is sandboxed: it is validated, but not sent to the matching engine.
+    pub fn test_stop_limit_buy_order<S, F>(
+        &self,
+        symbol: S,
+        qty: F,
+        price: f64,
+        stop_price: f64,
+        time_in_force: TimeInForce,
+    ) -> Result<()>
+    where
+        S: Into<String>,
+        F: Into<f64>,
+    {
+        let sell: OrderRequest = OrderRequest {
+            symbol: symbol.into(),
+            qty: qty.into(),
+            price,
+            stop_price: Some(stop_price),
+            order_side: OrderSide::Buy,
+            order_type: OrderType::StopLossLimit,
+            time_in_force: time_in_force,
+        };
+        let order = self.build_order(sell);
+        let request = build_signed_request(order, self.recv_window)?;
+        let data = self.client.post_signed(API_V3_ORDER_TEST, &request)?;
+        let _: TestResponse = from_str(data.as_str())?;
+
+        Ok(())
     }
 
     /// Place a custom order

--- a/src/account.rs
+++ b/src/account.rs
@@ -533,7 +533,7 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: Some(stop_price),
-            order_side: OrderSide::Sell,
+            order_side: OrderSide::Buy,
             order_type: OrderType::StopLossLimit,
             time_in_force: time_in_force,
         };

--- a/src/account.rs
+++ b/src/account.rs
@@ -438,7 +438,7 @@ impl Account {
             stop_price: Some(stop_price),
             order_side: OrderSide::Sell,
             order_type: OrderType::StopLossLimit,
-            time_in_force: time_in_force,
+            time_in_force,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -467,7 +467,7 @@ impl Account {
             stop_price: Some(stop_price),
             order_side: OrderSide::Sell,
             order_type: OrderType::StopLossLimit,
-            time_in_force: time_in_force,
+            time_in_force,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -494,7 +494,7 @@ impl Account {
             stop_price: Some(stop_price),
             order_side: OrderSide::Buy,
             order_type: OrderType::StopLossLimit,
-            time_in_force: time_in_force,
+            time_in_force,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -523,7 +523,7 @@ impl Account {
             stop_price: Some(stop_price),
             order_side: OrderSide::Buy,
             order_type: OrderType::StopLossLimit,
-            time_in_force: time_in_force,
+            time_in_force,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -550,9 +550,9 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: Some(stop_price),
-            order_side: order_side,
-            order_type: order_type,
-            time_in_force: time_in_force,
+            order_side,
+            order_type,
+            time_in_force,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -580,9 +580,9 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: None,
-            order_side: order_side,
-            order_type: order_type,
-            time_in_force: time_in_force,
+            order_side,
+            order_type,
+            time_in_force,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;

--- a/src/account.rs
+++ b/src/account.rs
@@ -81,7 +81,7 @@ impl Account {
     // Account Information
     pub fn get_account(&self) -> Result<AccountInformation> {
         let request = build_signed_request(BTreeMap::new(), self.recv_window)?;
-        self.client.get_signed(API::Spot(Spot::Account), &request)
+        self.client.get_signed(API::Spot(Spot::Account), Some(request))
     }
 
     // Balance for ONE Asset
@@ -112,7 +112,7 @@ impl Account {
         parameters.insert("symbol".into(), symbol.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        self.client.get_signed(API::Spot(Spot::OpenOrders), &request)
+        self.client.get_signed(API::Spot(Spot::OpenOrders), Some(request))
     }
 
     // All current open orders
@@ -120,7 +120,7 @@ impl Account {
         let parameters: BTreeMap<String, String> = BTreeMap::new();
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        self.client.get_signed(API::Spot(Spot::OpenOrders), &request)
+        self.client.get_signed(API::Spot(Spot::OpenOrders), Some(request))
     }
 
     // Cancel all open orders for ONE symbol
@@ -131,7 +131,7 @@ impl Account {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
         parameters.insert("symbol".into(), symbol.into());
         let request = build_signed_request(parameters, self.recv_window)?;
-        self.client.delete_signed(API::Spot(Spot::OpenOrders), &request)
+        self.client.delete_signed(API::Spot(Spot::OpenOrders), Some(request))
     }
 
     // Check an order's status
@@ -144,7 +144,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        self.client.get_signed(API::Spot(Spot::Order), &request)
+        self.client.get_signed(API::Spot(Spot::Order), Some(request))
     }
 
     /// Place a test status order
@@ -159,7 +159,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        self.client.get_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.get_signed::<()>(API::Spot(Spot::OrderTest), Some(request))
     }
 
     // Place a LIMIT order - BUY
@@ -179,7 +179,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed(API::Spot(Spot::Order), &request)
+        self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
     /// Place a test limit order - BUY
@@ -201,7 +201,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), request)
     }
 
     // Place a LIMIT order - SELL
@@ -221,7 +221,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed(API::Spot(Spot::Order), &request)
+        self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
     /// Place a test LIMIT order - SELL
@@ -243,7 +243,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), request)
     }
 
     // Place a MARKET order - BUY
@@ -263,7 +263,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed(API::Spot(Spot::Order), &request)
+        self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
     /// Place a test MARKET order - BUY
@@ -285,7 +285,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), request)
     }
 
     // Place a MARKET order with quote quantity - BUY
@@ -306,7 +306,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed(API::Spot(Spot::Order), &request)
+        self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
     /// Place a test MARKET order with quote quantity - BUY
@@ -329,7 +329,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), request)
     }
 
     // Place a MARKET order - SELL
@@ -349,7 +349,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed(API::Spot(Spot::Order), &request)
+        self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
     /// Place a test MARKET order - SELL
@@ -371,7 +371,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), request)
     }
 
     // Place a MARKET order with quote quantity - SELL
@@ -392,7 +392,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed(API::Spot(Spot::Order), &request)
+        self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
     /// Place a test MARKET order with quote quantity - SELL
@@ -415,7 +415,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), request)
     }
 
     /// Place a stop limit sell order
@@ -442,7 +442,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed(API::Spot(Spot::Order), &request)
+        self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
     /// Place a test stop limit sell order
@@ -471,7 +471,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), request)
     }
 
     /// Place a stop limit buy order
@@ -498,7 +498,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed(API::Spot(Spot::Order), &request)
+        self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
     /// Place a test stop limit buy order
@@ -527,7 +527,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), request)
     }
 
     /// Place a custom order
@@ -556,7 +556,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed(API::Spot(Spot::Order), &request)
+        self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
     /// Place a test custom order
@@ -586,7 +586,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), request)
     }
 
     // Check an order's status
@@ -599,7 +599,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        self.client.delete_signed(API::Spot(Spot::Order), &request)
+        self.client.delete_signed(API::Spot(Spot::Order), Some(request))
     }
 
     /// Place a test cancel order
@@ -613,7 +613,7 @@ impl Account {
         parameters.insert("symbol".into(), symbol.into());
         parameters.insert("orderId".into(), order_id.to_string());
         let request = build_signed_request(parameters, self.recv_window)?;
-        self.client.delete_signed::<()>(API::Spot(Spot::OrderTest), &request)
+        self.client.delete_signed::<()>(API::Spot(Spot::OrderTest), Some(request))
     }
 
     // Trade history
@@ -625,7 +625,7 @@ impl Account {
         parameters.insert("symbol".into(), symbol.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        self.client.get_signed(API::Spot(Spot::MyTrades), &request)
+        self.client.get_signed(API::Spot(Spot::MyTrades), Some(request))
     }
 
     fn build_order(&self, order: OrderRequest) -> BTreeMap<String, String> {

--- a/src/account.rs
+++ b/src/account.rs
@@ -5,11 +5,10 @@ use crate::errors::*;
 use std::collections::BTreeMap;
 use serde_json::from_str;
 
-static ORDER_TYPE_LIMIT: &str = "LIMIT";
-static ORDER_TYPE_MARKET: &str = "MARKET";
-static ORDER_SIDE_BUY: &str = "BUY";
-static ORDER_SIDE_SELL: &str = "SELL";
-static TIME_IN_FORCE_GTC: &str = "GTC";
+// static ORDER_TYPE_LIMIT: &str = "LIMIT";
+// static ORDER_TYPE_MARKET: &str = "MARKET";
+// static ORDER_SIDE_BUY: &str = "BUY";
+// static ORDER_SIDE_SELL: &str = "SELL";
 
 static API_V3_ORDER: &str = "/api/v3/order";
 
@@ -29,18 +28,48 @@ struct OrderRequest {
     pub qty: f64,
     pub price: f64,
     pub stop_price: Option<f64>,
-    pub order_side: String,
-    pub order_type: String,
-    pub time_in_force: String,
+    pub order_side: OrderSide,
+    pub order_type: OrderType,
+    pub time_in_force: TimeInForce,
 }
 
 struct OrderQuoteQuantityRequest {
     pub symbol: String,
     pub quote_order_qty: f64,
     pub price: f64,
-    pub order_side: String,
-    pub order_type: String,
-    pub time_in_force: String,
+    pub order_side: OrderSide,
+    pub order_type: OrderType,
+    pub time_in_force: TimeInForce,
+}
+
+pub enum OrderType {
+    Limit,
+    Market,
+    StopLossLimit,
+}
+
+impl From<OrderType> for String {
+    fn from(item: OrderType) -> Self {
+        match item {
+            OrderType::Limit => String::from("LIMIT"),
+            OrderType::Market => String::from("MARKET"),
+            OrderType::StopLossLimit => String::from("STOP_LOSS_LIMIT"),
+        }
+    }
+}
+
+pub enum OrderSide {
+    Buy,
+    Sell,
+}
+
+impl From<OrderSide> for String {
+    fn from(item: OrderSide) -> Self {
+        match item {
+            OrderSide::Buy => String::from("BUY"),
+            OrderSide::Sell => String::from("SELL"),
+        }
+    }
 }
 
 pub enum TimeInForce {
@@ -58,7 +87,6 @@ impl From<TimeInForce> for String {
         }
     }
 }
-
 
 impl Account {
     // Account Information
@@ -176,9 +204,9 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: None,
-            order_side: ORDER_SIDE_BUY.to_string(),
-            order_type: ORDER_TYPE_LIMIT.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Buy,
+            order_type: OrderType::Limit,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -201,9 +229,9 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: None,
-            order_side: ORDER_SIDE_BUY.to_string(),
-            order_type: ORDER_TYPE_LIMIT.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Buy,
+            order_type: OrderType::Limit,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -224,9 +252,9 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: None,
-            order_side: ORDER_SIDE_SELL.to_string(),
-            order_type: ORDER_TYPE_LIMIT.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Sell,
+            order_type: OrderType::Limit,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -249,9 +277,9 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: None,
-            order_side: ORDER_SIDE_SELL.to_string(),
-            order_type: ORDER_TYPE_LIMIT.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Sell,
+            order_type: OrderType::Limit,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -272,9 +300,9 @@ impl Account {
             qty: qty.into(),
             price: 0.0,
             stop_price: None,
-            order_side: ORDER_SIDE_BUY.to_string(),
-            order_type: ORDER_TYPE_MARKET.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Buy,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -297,9 +325,9 @@ impl Account {
             qty: qty.into(),
             price: 0.0,
             stop_price: None,
-            order_side: ORDER_SIDE_BUY.to_string(),
-            order_type: ORDER_TYPE_MARKET.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Buy,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -321,9 +349,9 @@ impl Account {
             symbol: symbol.into(),
             quote_order_qty: quote_order_qty.into(),
             price: 0.0,
-            order_side: ORDER_SIDE_BUY.to_string(),
-            order_type: ORDER_TYPE_MARKET.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Buy,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -347,9 +375,9 @@ impl Account {
             symbol: symbol.into(),
             quote_order_qty: quote_order_qty.into(),
             price: 0.0,
-            order_side: ORDER_SIDE_BUY.to_string(),
-            order_type: ORDER_TYPE_MARKET.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Buy,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -370,9 +398,9 @@ impl Account {
             qty: qty.into(),
             price: 0.0,
             stop_price: None,
-            order_side: ORDER_SIDE_SELL.to_string(),
-            order_type: ORDER_TYPE_MARKET.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Sell,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -395,9 +423,9 @@ impl Account {
             qty: qty.into(),
             price: 0.0,
             stop_price: None,
-            order_side: ORDER_SIDE_SELL.to_string(),
-            order_type: ORDER_TYPE_MARKET.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Sell,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -419,9 +447,9 @@ impl Account {
             symbol: symbol.into(),
             quote_order_qty: quote_order_qty.into(),
             price: 0.0,
-            order_side: ORDER_SIDE_SELL.to_string(),
-            order_type: ORDER_TYPE_MARKET.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Sell,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -445,9 +473,9 @@ impl Account {
             symbol: symbol.into(),
             quote_order_qty: quote_order_qty.into(),
             price: 0.0,
-            order_side: ORDER_SIDE_SELL.to_string(),
-            order_type: ORDER_TYPE_MARKET.to_string(),
-            time_in_force: TIME_IN_FORCE_GTC.to_string(),
+            order_side: OrderSide::Sell,
+            order_type: OrderType::Market,
+            time_in_force: TimeInForce::GTC,
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -475,9 +503,39 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: Some(stop_price),
-            order_side: String::from("SELL"),
-            order_type: String::from("STOP_LOSS_LIMIT"),
-            time_in_force: time_in_force.into(),
+            order_side: OrderSide::Sell,
+            order_type: OrderType::StopLossLimit,
+            time_in_force: time_in_force,
+        };
+        let order = self.build_order(sell);
+        let request = build_signed_request(order, self.recv_window)?;
+        let data = self.client.post_signed(API_V3_ORDER, &request)?;
+        let transaction: Transaction = from_str(data.as_str())?;
+
+        Ok(transaction)
+    }
+
+    /// Place a stop limit buy order
+    pub fn stop_limit_buy_order<S, F>(
+        &self,
+        symbol: S,
+        qty: F,
+        price: f64,
+        stop_price: f64,
+        time_in_force: TimeInForce,
+    ) -> Result<Transaction>
+    where
+        S: Into<String>,
+        F: Into<f64>,
+    {
+        let sell: OrderRequest = OrderRequest {
+            symbol: symbol.into(),
+            qty: qty.into(),
+            price,
+            stop_price: Some(stop_price),
+            order_side: OrderSide::Sell,
+            order_type: OrderType::StopLossLimit,
+            time_in_force: time_in_force,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -494,8 +552,8 @@ impl Account {
         qty: F,
         price: f64,
         stop_price: f64,
-        order_side: S,
-        order_type: S,
+        order_side: OrderSide,
+        order_type: OrderType,
         time_in_force: TimeInForce,
     ) -> Result<Transaction>
     where
@@ -507,9 +565,9 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: Some(stop_price),
-            order_side: order_side.into(),
-            order_type: order_type.into(),
-            time_in_force: time_in_force.into(),
+            order_side: order_side,
+            order_type: order_type,
+            time_in_force: time_in_force,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -527,8 +585,8 @@ impl Account {
         symbol: S,
         qty: F,
         price: f64,
-        order_side: S,
-        order_type: S,
+        order_side: OrderSide,
+        order_type: OrderType,
         time_in_force: TimeInForce,
     ) -> Result<()>
     where
@@ -540,9 +598,9 @@ impl Account {
             qty: qty.into(),
             price,
             stop_price: None,
-            order_side: order_side.into(),
-            order_type: order_type.into(),
-            time_in_force: time_in_force.into(),
+            order_side: order_side,
+            order_type: order_type,
+            time_in_force: time_in_force,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -605,22 +663,19 @@ impl Account {
         let mut order_parameters: BTreeMap<String, String> = BTreeMap::new();
 
         order_parameters.insert("symbol".into(), order.symbol);
-        order_parameters.insert("side".into(), order.order_side);
-        order_parameters.insert("type".into(), order.order_type);
+        order_parameters.insert("side".into(), order.order_side.into());
+        order_parameters.insert("type".into(), order.order_type.into());
         order_parameters.insert("quantity".into(), order.qty.to_string());
 
         if let Some(stop_price) = order.stop_price {
-            let valid_stop_price = format!("{:.7}", stop_price);
-            order_parameters.insert("stopPrice".into(), valid_stop_price.to_string());
+            order_parameters.insert("stopPrice".into(), stop_price.to_string());
         }
 
         if order.price != 0.0 {
-            let valid_price = format!("{:.7}", order.price);
-            order_parameters.insert("price".into(), valid_price.to_string());
-            order_parameters.insert("timeInForce".into(), order.time_in_force);
+            order_parameters.insert("price".into(), order.price.to_string());
+            order_parameters.insert("timeInForce".into(), order.time_in_force.into());
         }
 
-        println!("{:?}", order_parameters);
         order_parameters
     }
 
@@ -630,14 +685,13 @@ impl Account {
         let mut order_parameters: BTreeMap<String, String> = BTreeMap::new();
 
         order_parameters.insert("symbol".into(), order.symbol);
-        order_parameters.insert("side".into(), order.order_side);
-        order_parameters.insert("type".into(), order.order_type);
+        order_parameters.insert("side".into(), order.order_side.into());
+        order_parameters.insert("type".into(), order.order_type.into());
         order_parameters.insert("quoteOrderQty".into(), order.quote_order_qty.to_string());
 
         if order.price != 0.0 {
-            let valid_price = format!("{:.7}", order.price);
-            order_parameters.insert("price".into(), valid_price.to_string());
-            order_parameters.insert("timeInForce".into(), order.time_in_force);
+            order_parameters.insert("price".into(), order.price.to_string());
+            order_parameters.insert("timeInForce".into(), order.time_in_force.into());
         }
 
         order_parameters

--- a/src/account.rs
+++ b/src/account.rs
@@ -518,7 +518,7 @@ impl Account {
     /// Place a test stop limit sell order
     ///
     /// This order is sandboxed: it is validated, but not sent to the matching engine.
-    pub fn test_stop_limit_buy_order<S, F>(
+    pub fn test_stop_limit_sell_order<S, F>(
         &self,
         symbol: S,
         qty: F,

--- a/src/account.rs
+++ b/src/account.rs
@@ -43,7 +43,6 @@ struct OrderQuoteQuantityRequest {
     pub time_in_force: String,
 }
 
-// #[allow(non_camel_case_types)]
 pub enum TimeInForce {
     GTC,
     IOC,

--- a/src/account.rs
+++ b/src/account.rs
@@ -610,11 +610,13 @@ impl Account {
         order_parameters.insert("quantity".into(), order.qty.to_string());
 
         if let Some(stop_price) = order.stop_price {
-            order_parameters.insert("stopPrice".into(), stop_price.to_string());
+            let valid_stop_price = format!("{:.7}", stop_price);
+            order_parameters.insert("stopPrice".into(), valid_stop_price.to_string());
         }
 
         if order.price != 0.0 {
-            order_parameters.insert("price".into(), order.price.to_string());
+            let valid_price = format!("{:.7}", order.price);
+            order_parameters.insert("price".into(), valid_price.to_string());
             order_parameters.insert("timeInForce".into(), order.time_in_force);
         }
 
@@ -633,7 +635,8 @@ impl Account {
         order_parameters.insert("quoteOrderQty".into(), order.quote_order_qty.to_string());
 
         if order.price != 0.0 {
-            order_parameters.insert("price".into(), order.price.to_string());
+            let valid_price = format!("{:.7}", order.price);
+            order_parameters.insert("price".into(), valid_price.to_string());
             order_parameters.insert("timeInForce".into(), order.time_in_force);
         }
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -496,7 +496,7 @@ impl Account {
         stop_price: f64,
         order_side: S,
         order_type: S,
-        execution_type: S,
+        time_in_force: TimeInForce,
     ) -> Result<Transaction>
     where
         S: Into<String>,
@@ -509,7 +509,7 @@ impl Account {
             stop_price: Some(stop_price),
             order_side: order_side.into(),
             order_type: order_type.into(),
-            time_in_force: execution_type.into(),
+            time_in_force: time_in_force.into(),
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -529,7 +529,7 @@ impl Account {
         price: f64,
         order_side: S,
         order_type: S,
-        execution_type: S,
+        time_in_force: TimeInForce,
     ) -> Result<()>
     where
         S: Into<String>,
@@ -542,7 +542,7 @@ impl Account {
             stop_price: None,
             order_side: order_side.into(),
             order_type: order_type.into(),
-            time_in_force: execution_type.into(),
+            time_in_force: time_in_force.into(),
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -618,6 +618,7 @@ impl Account {
             order_parameters.insert("timeInForce".into(), order.time_in_force);
         }
 
+        println!("{:?}", order_parameters);
         order_parameters
     }
 

--- a/src/account.rs
+++ b/src/account.rs
@@ -3,7 +3,6 @@ use crate::model::*;
 use crate::client::*;
 use crate::errors::*;
 use std::collections::BTreeMap;
-use serde_json::from_str;
 use crate::api::API;
 use crate::api::Spot;
 
@@ -81,13 +80,8 @@ impl From<TimeInForce> for String {
 impl Account {
     // Account Information
     pub fn get_account(&self) -> Result<AccountInformation> {
-        let parameters: BTreeMap<String, String> = BTreeMap::new();
-
-        let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed(API::Spot(Spot::Account), &request)?;
-        let account_info: AccountInformation = from_str(data.as_str())?;
-
-        Ok(account_info)
+        let request = build_signed_request(BTreeMap::new(), self.recv_window)?;
+        self.client.get_signed(API::Spot(Spot::Account), &request)
     }
 
     // Balance for ONE Asset
@@ -118,10 +112,7 @@ impl Account {
         parameters.insert("symbol".into(), symbol.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed(API::Spot(Spot::OpenOrders), &request)?;
-        let order: Vec<Order> = from_str(data.as_str())?;
-
-        Ok(order)
+        self.client.get_signed(API::Spot(Spot::OpenOrders), &request)
     }
 
     // All current open orders
@@ -129,10 +120,7 @@ impl Account {
         let parameters: BTreeMap<String, String> = BTreeMap::new();
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed(API::Spot(Spot::OpenOrders), &request)?;
-        let order: Vec<Order> = from_str(data.as_str())?;
-
-        Ok(order)
+        self.client.get_signed(API::Spot(Spot::OpenOrders), &request)
     }
 
     // Cancel all open orders for ONE symbol
@@ -143,10 +131,7 @@ impl Account {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
         parameters.insert("symbol".into(), symbol.into());
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.delete_signed(API::Spot(Spot::OpenOrders), &request)?;
-        let order: Vec<OrderCanceled> = from_str(data.as_str())?;
-
-        Ok(order)
+        self.client.delete_signed(API::Spot(Spot::OpenOrders), &request)
     }
 
     // Check an order's status
@@ -159,10 +144,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed(API::Spot(Spot::Order), &request)?;
-        let order: Order = from_str(data.as_str())?;
-
-        Ok(order)
+        self.client.get_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test status order
@@ -177,10 +159,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.get_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     // Place a LIMIT order - BUY
@@ -200,10 +179,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
-        let transaction: Transaction = from_str(data.as_str())?;
-
-        Ok(transaction)
+        self.client.post_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test limit order - BUY
@@ -225,10 +201,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     // Place a LIMIT order - SELL
@@ -248,10 +221,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
-        let transaction: Transaction = from_str(data.as_str())?;
-
-        Ok(transaction)
+        self.client.post_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test LIMIT order - SELL
@@ -273,10 +243,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     // Place a MARKET order - BUY
@@ -296,10 +263,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
-        let transaction: Transaction = from_str(data.as_str())?;
-
-        Ok(transaction)
+        self.client.post_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test MARKET order - BUY
@@ -321,10 +285,7 @@ impl Account {
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     // Place a MARKET order with quote quantity - BUY
@@ -345,10 +306,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
-        let transaction: Transaction = from_str(data.as_str())?;
-
-        Ok(transaction)
+        self.client.post_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test MARKET order with quote quantity - BUY
@@ -371,10 +329,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     // Place a MARKET order - SELL
@@ -394,10 +349,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
-        let transaction: Transaction = from_str(data.as_str())?;
-
-        Ok(transaction)
+        self.client.post_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test MARKET order - SELL
@@ -419,10 +371,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     // Place a MARKET order with quote quantity - SELL
@@ -443,10 +392,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
-        let transaction: Transaction = from_str(data.as_str())?;
-
-        Ok(transaction)
+        self.client.post_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test MARKET order with quote quantity - SELL
@@ -469,10 +415,7 @@ impl Account {
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     /// Place a stop limit sell order
@@ -499,10 +442,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
-        let transaction: Transaction = from_str(data.as_str())?;
-
-        Ok(transaction)
+        self.client.post_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test stop limit sell order
@@ -531,10 +471,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     /// Place a stop limit buy order
@@ -561,10 +498,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
-        let transaction: Transaction = from_str(data.as_str())?;
-
-        Ok(transaction)
+        self.client.post_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test stop limit buy order
@@ -593,10 +527,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     /// Place a custom order
@@ -625,10 +556,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::Order), &request)?;
-        let transaction: Transaction = from_str(data.as_str())?;
-
-        Ok(transaction)
+        self.client.post_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test custom order
@@ -658,10 +586,7 @@ impl Account {
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
-        let data = self.client.post_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.post_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     // Check an order's status
@@ -674,10 +599,7 @@ impl Account {
         parameters.insert("orderId".into(), order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.delete_signed(API::Spot(Spot::Order), &request)?;
-        let order_canceled: OrderCanceled = from_str(data.as_str())?;
-
-        Ok(order_canceled)
+        self.client.delete_signed(API::Spot(Spot::Order), &request)
     }
 
     /// Place a test cancel order
@@ -690,12 +612,8 @@ impl Account {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
         parameters.insert("symbol".into(), symbol.into());
         parameters.insert("orderId".into(), order_id.to_string());
-
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.delete_signed(API::Spot(Spot::OrderTest), &request)?;
-        let _: TestResponse = from_str(data.as_str())?;
-
-        Ok(())
+        self.client.delete_signed::<()>(API::Spot(Spot::OrderTest), &request)
     }
 
     // Trade history
@@ -707,10 +625,7 @@ impl Account {
         parameters.insert("symbol".into(), symbol.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
-        let data = self.client.get_signed(API::Spot(Spot::MyTrades), &request)?;
-        let trade_history: Vec<TradeHistory> = from_str(data.as_str())?;
-
-        Ok(trade_history)
+        self.client.get_signed(API::Spot(Spot::MyTrades), &request)
     }
 
     fn build_order(&self, order: OrderRequest) -> BTreeMap<String, String> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -52,7 +52,6 @@ pub enum Futures {
 
 impl From<API> for String {
     fn from(item: API) -> Self {
-
         match item {
             API::Spot(route) => {
                 match route {
@@ -92,38 +91,6 @@ impl From<API> for String {
                 }
             }
         }
-
-        // match item {
-        //     API::Ping => String::from("/api/v3/ping"),
-        //     API::FuturesPing => String::from("/fapi/v1/ping"),
-        //     API::Time => String::from("/api/v3/time"),
-        //     API::FuturesTime => String::from("/fapi/v1/time"),
-        //     API::ExchangeInfo => String::from("/api/v3/exchangeInfo"),
-        //     API::FuturesExchangeInfo => String::from("/fapi/v1/exchangeInfo"),
-        //     API::Order => String::from("/api/v3/order"),
-        //     API::OrderTest => String::from("/api/v3/order/test"),
-        //     API::Account => String::from("/api/v3/account"),
-        //     API::OpenOrders => String::from("/api/v3/openOrders"),
-        //     API::MyTrades => String::from("/api/v3/myTrades"),
-        //     API::FuturesTrades => String::from("/fapi/v1/trades"),
-        //     API::FuturesHistoricalTrades => String::from("/fapi/v1/historicalTrades"),
-        //     API::FuturesAggTrades => String::from("/fapi/v1/aggTrades"),
-        //     API::Depth => String::from("/api/v3/depth"),
-        //     API::FuturesDepth => String::from("/fapi/v1/depth"),
-        //     API::Price => String::from("/api/v3/price"),
-        //     API::AvgPrice => String::from("/api/v3/avgPrice"),
-        //     API::BookTicker => String::from("/api/v3/ticker/bookTicker"),
-        //     API::FuturesBookTicker => String::from("/fapi/v1/ticker/bookTicker"),
-        //     API::Ticker24hr => String::from("/api/v3/ticker/24h"),
-        //     API::FuturesTicker24hr => String::from("/fapi/v1/ticker/24hr"),
-        //     API::FuturesTickerPrice => String::from("/fapi/v1/ticker/price"),
-        //     API::Klines => String::from("/api/v3/klines"),
-        //     API::FuturesKlines => String::from("/fapi/v1/klines"),
-        //     API::UserDataStream => String::from("/api/v3/userDataStream"),
-        //     API::FuturesPremiumIndex => String::from("/fapi/v1/premiumIndex"),
-        //     API::FuturesAllForceOrders => String::from("/fapi/v1/allForceOrders"),
-        //     API::FuturesOpenInterest => String::from("/fapi/v1/openInterest"),
-        // }
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -7,6 +7,126 @@ use crate::futures::market::*;
 use crate::userstream::*;
 use crate::client::*;
 
+pub enum API {
+    Spot(Spot),
+    Futures(Futures),
+}
+
+/// Endpoint for production and test orders.
+///
+/// Orders issued to test are validated, but not sent into the matching engine.
+pub enum Spot {
+    Ping,
+    Time,
+    ExchangeInfo,
+    Order,
+    OrderTest,
+    Account,
+    OpenOrders,
+    MyTrades,
+    Depth,
+    Price,
+    AvgPrice,
+    BookTicker,
+    Ticker24hr,
+    Klines,
+    UserDataStream,
+}
+
+pub enum Futures {
+    Ping,
+    Time,
+    ExchangeInfo,
+    Trades,
+    HistoricalTrades,
+    AggTrades,
+    Depth,
+    BookTicker,
+    Ticker24hr,
+    TickerPrice,
+    Klines,
+    PremiumIndex,
+    AllForceOrders,
+    OpenInterest,
+}
+
+impl From<API> for String {
+    fn from(item: API) -> Self {
+
+        match item {
+            API::Spot(route) => {
+                match route {
+                    Spot::Ping => String::from("/api/v3/ping"),
+                    Spot::Time => String::from("/api/v3/time"),
+                    Spot::ExchangeInfo => String::from("/api/v3/exchangeInfo"),
+                    Spot::Order => String::from("/api/v3/order"),
+                    Spot::OrderTest => String::from("/api/v3/order/test"),
+                    Spot::Account => String::from("/api/v3/account"),
+                    Spot::OpenOrders => String::from("/api/v3/openOrders"),
+                    Spot::MyTrades => String::from("/api/v3/myTrades"),
+                    Spot::Depth => String::from("/api/v3/depth"),
+                    Spot::Price => String::from("/api/v3/price"),
+                    Spot::AvgPrice => String::from("/api/v3/avgPrice"),
+                    Spot::BookTicker => String::from("/api/v3/ticker/bookTicker"),
+                    Spot::Ticker24hr => String::from("/api/v3/ticker/24h"),
+                    Spot::Klines => String::from("/api/v3/klines"),
+                    Spot::UserDataStream => String::from("/api/v3/userDataStream"),
+                }
+            },
+            API::Futures(route) => {
+                match route {
+                    Futures::Ping => String::from("/fapi/v1/ping"),
+                    Futures::Time => String::from("/fapi/v1/time"),
+                    Futures::ExchangeInfo => String::from("/fapi/v1/exchangeInfo"),
+                    Futures::Trades => String::from("/fapi/v1/trades"),
+                    Futures::HistoricalTrades => String::from("/fapi/v1/historicalTrades"),
+                    Futures::AggTrades => String::from("/fapi/v1/aggTrades"),
+                    Futures::Depth => String::from("/fapi/v1/depth"),
+                    Futures::BookTicker => String::from("/fapi/v1/ticker/bookTicker"),
+                    Futures::Ticker24hr => String::from("/fapi/v1/ticker/24hr"),
+                    Futures::TickerPrice => String::from("/fapi/v1/ticker/price"),
+                    Futures::Klines => String::from("/fapi/v1/klines"),
+                    Futures::PremiumIndex => String::from("/fapi/v1/premiumIndex"),
+                    Futures::AllForceOrders => String::from("/fapi/v1/allForceOrders"),
+                    Futures::OpenInterest => String::from("/fapi/v1/openInterest"),
+                }
+            }
+        }
+
+        // match item {
+        //     API::Ping => String::from("/api/v3/ping"),
+        //     API::FuturesPing => String::from("/fapi/v1/ping"),
+        //     API::Time => String::from("/api/v3/time"),
+        //     API::FuturesTime => String::from("/fapi/v1/time"),
+        //     API::ExchangeInfo => String::from("/api/v3/exchangeInfo"),
+        //     API::FuturesExchangeInfo => String::from("/fapi/v1/exchangeInfo"),
+        //     API::Order => String::from("/api/v3/order"),
+        //     API::OrderTest => String::from("/api/v3/order/test"),
+        //     API::Account => String::from("/api/v3/account"),
+        //     API::OpenOrders => String::from("/api/v3/openOrders"),
+        //     API::MyTrades => String::from("/api/v3/myTrades"),
+        //     API::FuturesTrades => String::from("/fapi/v1/trades"),
+        //     API::FuturesHistoricalTrades => String::from("/fapi/v1/historicalTrades"),
+        //     API::FuturesAggTrades => String::from("/fapi/v1/aggTrades"),
+        //     API::Depth => String::from("/api/v3/depth"),
+        //     API::FuturesDepth => String::from("/fapi/v1/depth"),
+        //     API::Price => String::from("/api/v3/price"),
+        //     API::AvgPrice => String::from("/api/v3/avgPrice"),
+        //     API::BookTicker => String::from("/api/v3/ticker/bookTicker"),
+        //     API::FuturesBookTicker => String::from("/fapi/v1/ticker/bookTicker"),
+        //     API::Ticker24hr => String::from("/api/v3/ticker/24h"),
+        //     API::FuturesTicker24hr => String::from("/fapi/v1/ticker/24hr"),
+        //     API::FuturesTickerPrice => String::from("/fapi/v1/ticker/price"),
+        //     API::Klines => String::from("/api/v3/klines"),
+        //     API::FuturesKlines => String::from("/fapi/v1/klines"),
+        //     API::UserDataStream => String::from("/api/v3/userDataStream"),
+        //     API::FuturesPremiumIndex => String::from("/fapi/v1/premiumIndex"),
+        //     API::FuturesAllForceOrders => String::from("/fapi/v1/allForceOrders"),
+        //     API::FuturesOpenInterest => String::from("/fapi/v1/openInterest"),
+        // }
+    }
+}
+
 pub trait Binance {
     fn new(api_key: Option<String>, secret_key: Option<String>) -> Self;
     fn new_with_config(

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,7 @@ use reqwest::StatusCode;
 use reqwest::blocking::Response;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue, USER_AGENT, CONTENT_TYPE};
 use sha2::Sha256;
+use crate::api::API;
 
 #[derive(Clone)]
 pub struct Client {
@@ -27,7 +28,7 @@ impl Client {
         }
     }
 
-    pub fn get_signed(&self, endpoint: &str, request: &str) -> Result<String> {
+    pub fn get_signed(&self, endpoint: API, request: &str) -> Result<String> {
         let url = self.sign_request(endpoint, request);
         let client = &self.inner_client;
         let response = client
@@ -38,7 +39,7 @@ impl Client {
         self.handler(response)
     }
 
-    pub fn post_signed(&self, endpoint: &str, request: &str) -> Result<String> {
+    pub fn post_signed(&self, endpoint: API, request: &str) -> Result<String> {
         let url = self.sign_request(endpoint, request);
         let client = &self.inner_client;
         let response = client
@@ -49,7 +50,7 @@ impl Client {
         self.handler(response)
     }
 
-    pub fn delete_signed(&self, endpoint: &str, request: &str) -> Result<String> {
+    pub fn delete_signed(&self, endpoint: API, request: &str) -> Result<String> {
         let url = self.sign_request(endpoint, request);
         let client = &self.inner_client;
         let response = client
@@ -60,8 +61,8 @@ impl Client {
         self.handler(response)
     }
 
-    pub fn get(&self, endpoint: &str, request: &str) -> Result<String> {
-        let mut url: String = format!("{}{}", self.host, endpoint);
+    pub fn get(&self, endpoint: API, request: &str) -> Result<String> {
+        let mut url: String = format!("{}{}", self.host, String::from(endpoint));
         if !request.is_empty() {
             url.push_str(format!("?{}", request).as_str());
         }
@@ -72,8 +73,8 @@ impl Client {
         self.handler(response)
     }
 
-    pub fn post(&self, endpoint: &str) -> Result<String> {
-        let url: String = format!("{}{}", self.host, endpoint);
+    pub fn post(&self, endpoint: API) -> Result<String> {
+        let url: String = format!("{}{}", self.host, String::from(endpoint));
 
         let client = &self.inner_client;
         let response = client
@@ -84,8 +85,8 @@ impl Client {
         self.handler(response)
     }
 
-    pub fn put(&self, endpoint: &str, listen_key: &str) -> Result<String> {
-        let url: String = format!("{}{}", self.host, endpoint);
+    pub fn put(&self, endpoint: API, listen_key: &str) -> Result<String> {
+        let url: String = format!("{}{}", self.host, String::from(endpoint));
         let data: String = format!("listenKey={}", listen_key);
 
         let client = &self.inner_client;
@@ -98,8 +99,8 @@ impl Client {
         self.handler(response)
     }
 
-    pub fn delete(&self, endpoint: &str, listen_key: &str) -> Result<String> {
-        let url: String = format!("{}{}", self.host, endpoint);
+    pub fn delete(&self, endpoint: API, listen_key: &str) -> Result<String> {
+        let url: String = format!("{}{}", self.host, String::from(endpoint));
         let data: String = format!("listenKey={}", listen_key);
 
         let client = &self.inner_client;
@@ -113,12 +114,12 @@ impl Client {
     }
 
     // Request must be signed
-    fn sign_request(&self, endpoint: &str, request: &str) -> String {
+    fn sign_request(&self, endpoint: API, request: &str) -> String {
         let mut signed_key = Hmac::<Sha256>::new_varkey(self.secret_key.as_bytes()).unwrap();
         signed_key.update(request.as_bytes());
         let signature = hex_encode(signed_key.finalize().into_bytes());
         let request_body: String = format!("{}&signature={}", request, signature);
-        let url: String = format!("{}{}?{}", self.host, endpoint, request_body);
+        let url: String = format!("{}{}?{}", self.host, String::from(endpoint), request_body);
 
         url
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -125,7 +125,9 @@ impl Client {
                 signed_key.update(request.as_bytes());
                 let signature = hex_encode(signed_key.finalize().into_bytes());
                 let request_body: String = format!("{:?}&signature={}", request, signature);
-                format!("{}{}?{}", self.host, String::from(endpoint), request_body)
+                let d = format!("{}{}?{}", self.host, String::from(endpoint), request_body);
+                println!("sign request {}", d);
+                d
             },
             None => {
                 let signed_key = Hmac::<Sha256>::new_varkey(self.secret_key.as_bytes()).unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -124,10 +124,8 @@ impl Client {
                 let mut signed_key = Hmac::<Sha256>::new_varkey(self.secret_key.as_bytes()).unwrap();
                 signed_key.update(request.as_bytes());
                 let signature = hex_encode(signed_key.finalize().into_bytes());
-                let request_body: String = format!("{:?}&signature={}", request, signature);
-                let d = format!("{}{}?{}", self.host, String::from(endpoint), request_body);
-                println!("sign request {}", d);
-                d
+                let request_body: String = format!("{}&signature={}", request, signature);
+                format!("{}{}?{}", self.host, String::from(endpoint), request_body)
             },
             None => {
                 let signed_key = Hmac::<Sha256>::new_varkey(self.secret_key.as_bytes()).unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,7 +30,7 @@ impl Client {
         }
     }
 
-    pub fn get_signed<T: DeserializeOwned>(&self, endpoint: API, request: &str) -> Result<T> {
+    pub fn get_signed<T: DeserializeOwned>(&self, endpoint: API, request: Option<String>) -> Result<T> {
         let url = self.sign_request(endpoint, request);
         let client = &self.inner_client;
         let response = client
@@ -41,8 +41,8 @@ impl Client {
         self.handler(response)
     }
 
-    pub fn post_signed<T: DeserializeOwned>(&self, endpoint: API, request: &str) -> Result<T> {
-        let url = self.sign_request(endpoint, request);
+    pub fn post_signed<T: DeserializeOwned>(&self, endpoint: API, request: String) -> Result<T> {
+        let url = self.sign_request(endpoint, Some(request));
         let client = &self.inner_client;
         let response = client
             .post(url.as_str())
@@ -52,7 +52,7 @@ impl Client {
         self.handler(response)
     }
 
-    pub fn delete_signed<T: DeserializeOwned>(&self, endpoint: API, request: &str) -> Result<T> {
+    pub fn delete_signed<T: DeserializeOwned>(&self, endpoint: API, request: Option<String>) -> Result<T> {
         let url = self.sign_request(endpoint, request);
         let client = &self.inner_client;
         let response = client
@@ -63,10 +63,12 @@ impl Client {
         self.handler(response)
     }
 
-    pub fn get<T: DeserializeOwned>(&self, endpoint: API, request: &str) -> Result<T> {
+    pub fn get<T: DeserializeOwned>(&self, endpoint: API, request: Option<String>) -> Result<T> {
         let mut url: String = format!("{}{}", self.host, String::from(endpoint));
-        if !request.is_empty() {
-            url.push_str(format!("?{}", request).as_str());
+        if let Some(request) = request {
+            if !request.is_empty() {
+                url.push_str(format!("?{}", request).as_str());
+            }
         }
 
         let client = &self.inner_client;
@@ -116,12 +118,22 @@ impl Client {
     }
 
     // Request must be signed
-    fn sign_request(&self, endpoint: API, request: &str) -> String {
-        let mut signed_key = Hmac::<Sha256>::new_varkey(self.secret_key.as_bytes()).unwrap();
-        signed_key.update(request.as_bytes());
-        let signature = hex_encode(signed_key.finalize().into_bytes());
-        let request_body: String = format!("{}&signature={}", request, signature);
-        format!("{}{}?{}", self.host, String::from(endpoint), request_body)
+    fn sign_request(&self, endpoint: API, request: Option<String>) -> String {
+        match request {
+            Some(request) => {
+                let mut signed_key = Hmac::<Sha256>::new_varkey(self.secret_key.as_bytes()).unwrap();
+                signed_key.update(request.as_bytes());
+                let signature = hex_encode(signed_key.finalize().into_bytes());
+                let request_body: String = format!("{:?}&signature={}", request, signature);
+                format!("{}{}?{}", self.host, String::from(endpoint), request_body)
+            },
+            None => {
+                let signed_key = Hmac::<Sha256>::new_varkey(self.secret_key.as_bytes()).unwrap();
+                let signature = hex_encode(signed_key.finalize().into_bytes());
+                let request_body: String = format!("&signature={}", signature);
+                format!("{}{}?{}", self.host, String::from(endpoint), request_body)
+            }
+        }
     }
 
     fn build_headers(&self, content_type: bool) -> Result<HeaderMap> {

--- a/src/futures/general.rs
+++ b/src/futures/general.rs
@@ -1,7 +1,6 @@
 use crate::futures::model::*;
 use crate::client::*;
 use crate::errors::*;
-use serde_json::from_str;
 use crate::api::API;
 use crate::api::Futures;
 
@@ -13,25 +12,19 @@ pub struct FuturesGeneral {
 impl FuturesGeneral {
     // Test connectivity
     pub fn ping(&self) -> Result<String> {
-        self.client.get(API::Futures(Futures::Ping), "")?;
+        self.client.get(API::Futures(Futures::Ping), None)?;
         Ok("pong".into())
     }
 
     // Check server time
     pub fn get_server_time(&self) -> Result<ServerTime> {
-        let data: String = self.client.get(API::Futures(Futures::Time), "")?;
-        let server_time: ServerTime = from_str(data.as_str())?;
-
-        Ok(server_time)
+        self.client.get(API::Futures(Futures::Time), None)
     }
 
     // Obtain exchange information
     // - Current exchange trading rules and symbol information
     pub fn exchange_info(&self) -> Result<ExchangeInformation> {
-        let data: String = self.client.get(API::Futures(Futures::ExchangeInfo), "")?;
-        let info: ExchangeInformation = from_str(data.as_str())?;
-
-        Ok(info)
+        self.client.get(API::Futures(Futures::ExchangeInfo), None)
     }
 
     // Get Symbol information

--- a/src/futures/general.rs
+++ b/src/futures/general.rs
@@ -2,6 +2,8 @@ use crate::futures::model::*;
 use crate::client::*;
 use crate::errors::*;
 use serde_json::from_str;
+use crate::api::API;
+use crate::api::Futures;
 
 #[derive(Clone)]
 pub struct FuturesGeneral {
@@ -11,13 +13,13 @@ pub struct FuturesGeneral {
 impl FuturesGeneral {
     // Test connectivity
     pub fn ping(&self) -> Result<String> {
-        self.client.get("/fapi/v1/ping", "")?;
+        self.client.get(API::Futures(Futures::Ping), "")?;
         Ok("pong".into())
     }
 
     // Check server time
     pub fn get_server_time(&self) -> Result<ServerTime> {
-        let data: String = self.client.get("/fapi/v1/time", "")?;
+        let data: String = self.client.get(API::Futures(Futures::Time), "")?;
         let server_time: ServerTime = from_str(data.as_str())?;
 
         Ok(server_time)
@@ -26,7 +28,7 @@ impl FuturesGeneral {
     // Obtain exchange information
     // - Current exchange trading rules and symbol information
     pub fn exchange_info(&self) -> Result<ExchangeInformation> {
-        let data: String = self.client.get("/fapi/v1/exchangeInfo", "")?;
+        let data: String = self.client.get(API::Futures(Futures::ExchangeInfo), "")?;
         let info: ExchangeInformation = from_str(data.as_str())?;
 
         Ok(info)

--- a/src/futures/market.rs
+++ b/src/futures/market.rs
@@ -26,6 +26,8 @@ use crate::client::*;
 use crate::errors::*;
 use std::collections::BTreeMap;
 use serde_json::{Value, from_str};
+use crate::api::API;
+use crate::api::Futures;
 
 // TODO
 // Make enums for Strings
@@ -49,7 +51,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/fapi/v1/depth", &request)?;
+        let data = self.client.get(API::Futures(Futures::Depth), &request)?;
 
         let order_book: OrderBook = from_str(data.as_str())?;
 
@@ -65,7 +67,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/fapi/v1/trades", &request)?;
+        let data = self.client.get(API::Futures(Futures::Trades), &request)?;
 
         let trades: Trades = from_str(data.as_str())?;
 
@@ -97,7 +99,7 @@ impl FuturesMarket {
 
         let data = self
             .client
-            .get_signed("/fapi/v1/historicalTrades", &request)?;
+            .get_signed(API::Futures(Futures::HistoricalTrades), &request)?;
 
         let trades: Trades = from_str(data.as_str())?;
 
@@ -134,7 +136,7 @@ impl FuturesMarket {
 
         let request = build_request(&parameters);
 
-        let data = self.client.get("/fapi/v1/aggTrades", &request)?;
+        let data = self.client.get(API::Futures(Futures::AggTrades), &request)?;
 
         let aggtrades: AggTrades = from_str(data.as_str())?;
 
@@ -171,7 +173,7 @@ impl FuturesMarket {
 
         let request = build_request(&parameters);
 
-        let data = self.client.get("/fapi/v1/klines", &request)?;
+        let data = self.client.get(API::Futures(Futures::Klines), &request)?;
         let parsed_data: Vec<Vec<Value>> = from_str(data.as_str())?;
 
         let klines = KlineSummaries::AllKlineSummaries(
@@ -205,7 +207,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/fapi/v1/ticker/24hr", &request)?;
+        let data = self.client.get(API::Futures(Futures::Ticker24hr), &request)?;
 
         let stats: PriceStats = from_str(data.as_str())?;
 
@@ -222,7 +224,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/fapi/v1/ticker/price", &request)?;
+        let data = self.client.get(API::Futures(Futures::TickerPrice), &request)?;
         let symbol_price: SymbolPrice = from_str(data.as_str())?;
 
         Ok(symbol_price)
@@ -231,7 +233,7 @@ impl FuturesMarket {
     // Symbols order book ticker
     // -> Best price/qty on the order book for ALL symbols.
     pub fn get_all_book_tickers(&self) -> Result<BookTickers> {
-        let data = self.client.get("/fapi/v1/ticker/bookTicker", "")?;
+        let data = self.client.get(API::Futures(Futures::BookTicker), "")?;
 
         let book_tickers: BookTickers = from_str(data.as_str())?;
 
@@ -248,14 +250,14 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/fapi/v1/ticker/bookTicker", &request)?;
+        let data = self.client.get(API::Futures(Futures::BookTicker), &request)?;
         let ticker: Tickers = from_str(data.as_str())?;
 
         Ok(ticker)
     }
 
     pub fn get_mark_prices(&self) -> Result<MarkPrices> {
-        let data = self.client.get("/fapi/v1/premiumIndex", "")?;
+        let data = self.client.get(API::Futures(Futures::PremiumIndex), "")?;
 
         let mark_prices: MarkPrices = from_str(data.as_str())?;
 
@@ -263,7 +265,7 @@ impl FuturesMarket {
     }
 
     pub fn get_all_liquidation_orders(&self) -> Result<LiquidationOrders> {
-        let data = self.client.get("/fapi/v1/allForceOrders", "")?;
+        let data = self.client.get(API::Futures(Futures::AllForceOrders), "")?;
         let liquidation_orders: LiquidationOrders = from_str(data.as_str())?;
 
         Ok(liquidation_orders)
@@ -278,7 +280,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/fapi/v1/openInterest", &request)?;
+        let data = self.client.get(API::Futures(Futures::OpenInterest), &request)?;
         let open_interest: OpenInterest = from_str(data.as_str())?;
 
         Ok(open_interest)

--- a/src/futures/market.rs
+++ b/src/futures/market.rs
@@ -25,7 +25,7 @@ use crate::futures::model::*;
 use crate::client::*;
 use crate::errors::*;
 use std::collections::BTreeMap;
-use serde_json::{Value, from_str};
+use serde_json::Value;
 use crate::api::API;
 use crate::api::Futures;
 
@@ -51,11 +51,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Futures(Futures::Depth), &request)?;
-
-        let order_book: OrderBook = from_str(data.as_str())?;
-
-        Ok(order_book)
+        self.client.get(API::Futures(Futures::Depth), &request)
     }
 
     pub fn get_trades<S>(&self, symbol: S) -> Result<Trades>
@@ -67,11 +63,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Futures(Futures::Trades), &request)?;
-
-        let trades: Trades = from_str(data.as_str())?;
-
-        Ok(trades)
+        self.client.get(API::Futures(Futures::Trades), &request)
     }
 
     // TODO This may be incomplete, as it hasn't been tested
@@ -97,13 +89,7 @@ impl FuturesMarket {
 
         let request = build_signed_request(parameters, self.recv_window)?;
 
-        let data = self
-            .client
-            .get_signed(API::Futures(Futures::HistoricalTrades), &request)?;
-
-        let trades: Trades = from_str(data.as_str())?;
-
-        Ok(trades)
+        self.client.get_signed(API::Futures(Futures::HistoricalTrades), &request)
     }
 
     pub fn get_agg_trades<S1, S2, S3, S4, S5>(
@@ -136,11 +122,7 @@ impl FuturesMarket {
 
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Futures(Futures::AggTrades), &request)?;
-
-        let aggtrades: AggTrades = from_str(data.as_str())?;
-
-        Ok(aggtrades)
+        self.client.get(API::Futures(Futures::AggTrades), &request)
     }
 
     // Returns up to 'limit' klines for given symbol and interval ("1m", "5m", ...)
@@ -173,12 +155,12 @@ impl FuturesMarket {
 
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Futures(Futures::Klines), &request)?;
-        let parsed_data: Vec<Vec<Value>> = from_str(data.as_str())?;
+        let data: Vec<Vec<Value>> = self
+            .client
+            .get(API::Futures(Futures::Klines), &request)?;
 
         let klines = KlineSummaries::AllKlineSummaries(
-            parsed_data
-                .iter()
+            data.iter()
                 .map(|row| KlineSummary {
                     open_time: to_i64(&row[0]),
                     open: to_f64(&row[1]),
@@ -207,11 +189,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Futures(Futures::Ticker24hr), &request)?;
-
-        let stats: PriceStats = from_str(data.as_str())?;
-
-        Ok(stats)
+        self.client.get(API::Futures(Futures::Ticker24hr), &request)
     }
 
     // Latest price for ONE symbol.
@@ -224,20 +202,13 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Futures(Futures::TickerPrice), &request)?;
-        let symbol_price: SymbolPrice = from_str(data.as_str())?;
-
-        Ok(symbol_price)
+        self.client.get(API::Futures(Futures::TickerPrice), &request)
     }
 
     // Symbols order book ticker
     // -> Best price/qty on the order book for ALL symbols.
     pub fn get_all_book_tickers(&self) -> Result<BookTickers> {
-        let data = self.client.get(API::Futures(Futures::BookTicker), "")?;
-
-        let book_tickers: BookTickers = from_str(data.as_str())?;
-
-        Ok(book_tickers)
+        self.client.get(API::Futures(Futures::BookTicker), "")
     }
 
     // -> Best price/qty on the order book for ONE symbol
@@ -246,29 +217,17 @@ impl FuturesMarket {
         S: Into<String>,
     {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
-
-        let data = self.client.get(API::Futures(Futures::BookTicker), &request)?;
-        let ticker: Tickers = from_str(data.as_str())?;
-
-        Ok(ticker)
+        self.client.get(API::Futures(Futures::BookTicker), &request)
     }
 
     pub fn get_mark_prices(&self) -> Result<MarkPrices> {
-        let data = self.client.get(API::Futures(Futures::PremiumIndex), "")?;
-
-        let mark_prices: MarkPrices = from_str(data.as_str())?;
-
-        Ok(mark_prices)
+        self.client.get(API::Futures(Futures::PremiumIndex), "")
     }
 
     pub fn get_all_liquidation_orders(&self) -> Result<LiquidationOrders> {
-        let data = self.client.get(API::Futures(Futures::AllForceOrders), "")?;
-        let liquidation_orders: LiquidationOrders = from_str(data.as_str())?;
-
-        Ok(liquidation_orders)
+        self.client.get(API::Futures(Futures::AllForceOrders), "")
     }
 
     pub fn open_interest<S>(&self, symbol: S) -> Result<OpenInterest>
@@ -276,13 +235,8 @@ impl FuturesMarket {
         S: Into<String>,
     {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
-
-        let data = self.client.get(API::Futures(Futures::OpenInterest), &request)?;
-        let open_interest: OpenInterest = from_str(data.as_str())?;
-
-        Ok(open_interest)
+        self.client.get(API::Futures(Futures::OpenInterest), &request)
     }
 }

--- a/src/futures/market.rs
+++ b/src/futures/market.rs
@@ -51,7 +51,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        self.client.get(API::Futures(Futures::Depth), &request)
+        self.client.get(API::Futures(Futures::Depth), Some(request))
     }
 
     pub fn get_trades<S>(&self, symbol: S) -> Result<Trades>
@@ -59,11 +59,9 @@ impl FuturesMarket {
         S: Into<String>,
     {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
-
-        self.client.get(API::Futures(Futures::Trades), &request)
+        self.client.get(API::Futures(Futures::Trades), Some(request))
     }
 
     // TODO This may be incomplete, as it hasn't been tested
@@ -89,7 +87,7 @@ impl FuturesMarket {
 
         let request = build_signed_request(parameters, self.recv_window)?;
 
-        self.client.get_signed(API::Futures(Futures::HistoricalTrades), &request)
+        self.client.get_signed(API::Futures(Futures::HistoricalTrades), Some(request))
     }
 
     pub fn get_agg_trades<S1, S2, S3, S4, S5>(
@@ -122,7 +120,7 @@ impl FuturesMarket {
 
         let request = build_request(&parameters);
 
-        self.client.get(API::Futures(Futures::AggTrades), &request)
+        self.client.get(API::Futures(Futures::AggTrades), Some(request))
     }
 
     // Returns up to 'limit' klines for given symbol and interval ("1m", "5m", ...)
@@ -157,7 +155,7 @@ impl FuturesMarket {
 
         let data: Vec<Vec<Value>> = self
             .client
-            .get(API::Futures(Futures::Klines), &request)?;
+            .get(API::Futures(Futures::Klines), Some(request))?;
 
         let klines = KlineSummaries::AllKlineSummaries(
             data.iter()
@@ -189,7 +187,7 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        self.client.get(API::Futures(Futures::Ticker24hr), &request)
+        self.client.get(API::Futures(Futures::Ticker24hr), Some(request))
     }
 
     // Latest price for ONE symbol.
@@ -202,13 +200,13 @@ impl FuturesMarket {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        self.client.get(API::Futures(Futures::TickerPrice), &request)
+        self.client.get(API::Futures(Futures::TickerPrice), Some(request))
     }
 
     // Symbols order book ticker
     // -> Best price/qty on the order book for ALL symbols.
     pub fn get_all_book_tickers(&self) -> Result<BookTickers> {
-        self.client.get(API::Futures(Futures::BookTicker), "")
+        self.client.get(API::Futures(Futures::BookTicker), None)
     }
 
     // -> Best price/qty on the order book for ONE symbol
@@ -219,15 +217,15 @@ impl FuturesMarket {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
-        self.client.get(API::Futures(Futures::BookTicker), &request)
+        self.client.get(API::Futures(Futures::BookTicker), Some(request))
     }
 
     pub fn get_mark_prices(&self) -> Result<MarkPrices> {
-        self.client.get(API::Futures(Futures::PremiumIndex), "")
+        self.client.get(API::Futures(Futures::PremiumIndex), None)
     }
 
     pub fn get_all_liquidation_orders(&self) -> Result<LiquidationOrders> {
-        self.client.get(API::Futures(Futures::AllForceOrders), "")
+        self.client.get(API::Futures(Futures::AllForceOrders), None)
     }
 
     pub fn open_interest<S>(&self, symbol: S) -> Result<OpenInterest>
@@ -237,6 +235,6 @@ impl FuturesMarket {
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
-        self.client.get(API::Futures(Futures::OpenInterest), &request)
+        self.client.get(API::Futures(Futures::OpenInterest), Some(request))
     }
 }

--- a/src/general.rs
+++ b/src/general.rs
@@ -1,6 +1,8 @@
 use crate::model::*;
 use crate::client::*;
 use crate::errors::*;
+use crate::api::API;
+use crate::api::Spot;
 
 use serde_json::from_str;
 
@@ -12,14 +14,14 @@ pub struct General {
 impl General {
     // Test connectivity
     pub fn ping(&self) -> Result<String> {
-        self.client.get("/api/v3/ping", "")?;
+        self.client.get(API::Spot(Spot::Ping), "")?;
 
         Ok("pong".into())
     }
 
     // Check server time
     pub fn get_server_time(&self) -> Result<ServerTime> {
-        let data: String = self.client.get("/api/v3/time", "")?;
+        let data: String = self.client.get(API::Spot(Spot::Time), "")?;
 
         let server_time: ServerTime = from_str(data.as_str())?;
 
@@ -29,7 +31,7 @@ impl General {
     // Obtain exchange information
     // - Current exchange trading rules and symbol information
     pub fn exchange_info(&self) -> Result<ExchangeInformation> {
-        let data: String = self.client.get("/api/v3/exchangeInfo", "")?;
+        let data: String = self.client.get(API::Spot(Spot::ExchangeInfo), "")?;
 
         let info: ExchangeInformation = from_str(data.as_str())?;
 

--- a/src/general.rs
+++ b/src/general.rs
@@ -14,14 +14,14 @@ pub struct General {
 impl General {
     // Test connectivity
     pub fn ping(&self) -> Result<String> {
-        self.client.get(API::Spot(Spot::Ping), "")?;
+        self.client.get(API::Spot(Spot::Ping), None)?;
 
         Ok("pong".into())
     }
 
     // Check server time
     pub fn get_server_time(&self) -> Result<ServerTime> {
-        let data: String = self.client.get(API::Spot(Spot::Time), "")?;
+        let data: String = self.client.get(API::Spot(Spot::Time), None)?;
 
         let server_time: ServerTime = from_str(data.as_str())?;
 
@@ -31,7 +31,7 @@ impl General {
     // Obtain exchange information
     // - Current exchange trading rules and symbol information
     pub fn exchange_info(&self) -> Result<ExchangeInformation> {
-        let data: String = self.client.get(API::Spot(Spot::ExchangeInfo), "")?;
+        let data: String = self.client.get(API::Spot(Spot::ExchangeInfo), None)?;
 
         let info: ExchangeInformation = from_str(data.as_str())?;
 

--- a/src/market.rs
+++ b/src/market.rs
@@ -25,7 +25,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        self.client.get(API::Spot(Spot::Depth), &request)
+        self.client.get(API::Spot(Spot::Depth), Some(request))
     }
 
     // Order book at a custom depth. Currently supported values
@@ -40,12 +40,12 @@ impl Market {
         parameters.insert("limit".into(), depth.to_string());
         let request = build_request(&parameters);
 
-        self.client.get(API::Spot(Spot::Depth), &request)
+        self.client.get(API::Spot(Spot::Depth), Some(request))
     }
 
     // Latest price for ALL symbols.
     pub fn get_all_prices(&self) -> Result<Prices> {
-        self.client.get(API::Spot(Spot::Price), "")
+        self.client.get(API::Spot(Spot::Price), None)
     }
 
     // Latest price for ONE symbol.
@@ -58,7 +58,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        self.client.get(API::Spot(Spot::Price), &request)
+        self.client.get(API::Spot(Spot::Price), Some(request))
     }
 
     // Average price for ONE symbol.
@@ -71,13 +71,13 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        self.client.get(API::Spot(Spot::AvgPrice), &request)
+        self.client.get(API::Spot(Spot::AvgPrice), Some(request))
     }
 
     // Symbols order book ticker
     // -> Best price/qty on the order book for ALL symbols.
     pub fn get_all_book_tickers(&self) -> Result<BookTickers> {
-        self.client.get(API::Spot(Spot::BookTicker), "")
+        self.client.get(API::Spot(Spot::BookTicker), None)
     }
 
     // -> Best price/qty on the order book for ONE symbol
@@ -90,7 +90,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        self.client.get(API::Spot(Spot::BookTicker), &request)
+        self.client.get(API::Spot(Spot::BookTicker), Some(request))
     }
 
     // 24hr ticker price change statistics
@@ -103,12 +103,12 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        self.client.get(API::Spot(Spot::Ticker24hr), &request)
+        self.client.get(API::Spot(Spot::Ticker24hr), Some(request))
     }
 
     // 24hr ticker price change statistics for all symbols
     pub fn get_all_24h_price_stats(&self) -> Result<Vec<PriceStats>> {
-        self.client.get(API::Spot(Spot::Ticker24hr), "")
+        self.client.get(API::Spot(Spot::Ticker24hr), None)
     }
 
     // Returns up to 'limit' klines for given symbol and interval ("1m", "5m", ...)
@@ -140,8 +140,7 @@ impl Market {
         }
 
         let request = build_request(&parameters);
-
-        let data: Vec<Vec<Value>> = self.client.get(API::Spot(Spot::Klines), &request)?;
+        let data: Vec<Vec<Value>> = self.client.get(API::Spot(Spot::Klines), Some(request))?;
 
         let klines = KlineSummaries::AllKlineSummaries(
             data.iter()

--- a/src/market.rs
+++ b/src/market.rs
@@ -4,6 +4,8 @@ use crate::client::*;
 use crate::errors::*;
 use std::collections::BTreeMap;
 use serde_json::{Value, from_str};
+use crate::api::API;
+use crate::api::Spot;
 
 #[derive(Clone)]
 pub struct Market {
@@ -23,7 +25,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/api/v3/depth", &request)?;
+        let data = self.client.get(API::Spot(Spot::Depth), &request)?;
         let order_book: OrderBook = from_str(data.as_str())?;
 
         Ok(order_book)
@@ -41,7 +43,7 @@ impl Market {
         parameters.insert("limit".into(), depth.to_string());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/api/v3/depth", &request)?;
+        let data = self.client.get(API::Spot(Spot::Depth), &request)?;
         let order_book: OrderBook = from_str(data.as_str())?;
 
         Ok(order_book)
@@ -49,7 +51,7 @@ impl Market {
 
     // Latest price for ALL symbols.
     pub fn get_all_prices(&self) -> Result<Prices> {
-        let data = self.client.get("/api/v3/ticker/price", "")?;
+        let data = self.client.get(API::Spot(Spot::Price), "")?;
 
         let prices: Prices = from_str(data.as_str())?;
 
@@ -66,7 +68,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/api/v3/ticker/price", &request)?;
+        let data = self.client.get(API::Spot(Spot::Price), &request)?;
         let symbol_price: SymbolPrice = from_str(data.as_str())?;
 
         Ok(symbol_price)
@@ -82,7 +84,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/api/v3/avgPrice", &request)?;
+        let data = self.client.get(API::Spot(Spot::AvgPrice), &request)?;
         let average_price: AveragePrice = from_str(data.as_str())?;
 
         Ok(average_price)
@@ -91,7 +93,7 @@ impl Market {
     // Symbols order book ticker
     // -> Best price/qty on the order book for ALL symbols.
     pub fn get_all_book_tickers(&self) -> Result<BookTickers> {
-        let data = self.client.get("/api/v3/ticker/bookTicker", "")?;
+        let data = self.client.get(API::Spot(Spot::BookTicker), "")?;
 
         let book_tickers: BookTickers = from_str(data.as_str())?;
 
@@ -108,7 +110,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/api/v3/ticker/bookTicker", &request)?;
+        let data = self.client.get(API::Spot(Spot::BookTicker), &request)?;
         let ticker: Tickers = from_str(data.as_str())?;
 
         Ok(ticker)
@@ -124,7 +126,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get("/api/v3/ticker/24hr", &request)?;
+        let data = self.client.get(API::Spot(Spot::Ticker24hr), &request)?;
 
         let stats: PriceStats = from_str(data.as_str())?;
 
@@ -133,7 +135,7 @@ impl Market {
 
     // 24hr ticker price change statistics for all symbols
     pub fn get_all_24h_price_stats(&self) -> Result<Vec<PriceStats>> {
-        let data = self.client.get("/api/v3/ticker/24hr", "")?;
+        let data = self.client.get(API::Spot(Spot::Ticker24hr), "")?;
 
         let stats: Vec<PriceStats> = from_str(data.as_str())?;
 
@@ -170,7 +172,7 @@ impl Market {
 
         let request = build_request(&parameters);
 
-        let data = self.client.get("/api/v3/klines", &request)?;
+        let data = self.client.get(API::Spot(Spot::Klines), &request)?;
         let parsed_data: Vec<Vec<Value>> = from_str(data.as_str())?;
 
         let klines = KlineSummaries::AllKlineSummaries(

--- a/src/market.rs
+++ b/src/market.rs
@@ -3,7 +3,7 @@ use crate::model::*;
 use crate::client::*;
 use crate::errors::*;
 use std::collections::BTreeMap;
-use serde_json::{Value, from_str};
+use serde_json::Value;
 use crate::api::API;
 use crate::api::Spot;
 
@@ -25,10 +25,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Spot(Spot::Depth), &request)?;
-        let order_book: OrderBook = from_str(data.as_str())?;
-
-        Ok(order_book)
+        self.client.get(API::Spot(Spot::Depth), &request)
     }
 
     // Order book at a custom depth. Currently supported values
@@ -43,19 +40,12 @@ impl Market {
         parameters.insert("limit".into(), depth.to_string());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Spot(Spot::Depth), &request)?;
-        let order_book: OrderBook = from_str(data.as_str())?;
-
-        Ok(order_book)
+        self.client.get(API::Spot(Spot::Depth), &request)
     }
 
     // Latest price for ALL symbols.
     pub fn get_all_prices(&self) -> Result<Prices> {
-        let data = self.client.get(API::Spot(Spot::Price), "")?;
-
-        let prices: Prices = from_str(data.as_str())?;
-
-        Ok(prices)
+        self.client.get(API::Spot(Spot::Price), "")
     }
 
     // Latest price for ONE symbol.
@@ -68,10 +58,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Spot(Spot::Price), &request)?;
-        let symbol_price: SymbolPrice = from_str(data.as_str())?;
-
-        Ok(symbol_price)
+        self.client.get(API::Spot(Spot::Price), &request)
     }
 
     // Average price for ONE symbol.
@@ -84,20 +71,13 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Spot(Spot::AvgPrice), &request)?;
-        let average_price: AveragePrice = from_str(data.as_str())?;
-
-        Ok(average_price)
+        self.client.get(API::Spot(Spot::AvgPrice), &request)
     }
 
     // Symbols order book ticker
     // -> Best price/qty on the order book for ALL symbols.
     pub fn get_all_book_tickers(&self) -> Result<BookTickers> {
-        let data = self.client.get(API::Spot(Spot::BookTicker), "")?;
-
-        let book_tickers: BookTickers = from_str(data.as_str())?;
-
-        Ok(book_tickers)
+        self.client.get(API::Spot(Spot::BookTicker), "")
     }
 
     // -> Best price/qty on the order book for ONE symbol
@@ -110,10 +90,7 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Spot(Spot::BookTicker), &request)?;
-        let ticker: Tickers = from_str(data.as_str())?;
-
-        Ok(ticker)
+        self.client.get(API::Spot(Spot::BookTicker), &request)
     }
 
     // 24hr ticker price change statistics
@@ -126,20 +103,12 @@ impl Market {
         parameters.insert("symbol".into(), symbol.into());
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Spot(Spot::Ticker24hr), &request)?;
-
-        let stats: PriceStats = from_str(data.as_str())?;
-
-        Ok(stats)
+        self.client.get(API::Spot(Spot::Ticker24hr), &request)
     }
 
     // 24hr ticker price change statistics for all symbols
     pub fn get_all_24h_price_stats(&self) -> Result<Vec<PriceStats>> {
-        let data = self.client.get(API::Spot(Spot::Ticker24hr), "")?;
-
-        let stats: Vec<PriceStats> = from_str(data.as_str())?;
-
-        Ok(stats)
+        self.client.get(API::Spot(Spot::Ticker24hr), "")
     }
 
     // Returns up to 'limit' klines for given symbol and interval ("1m", "5m", ...)
@@ -172,12 +141,10 @@ impl Market {
 
         let request = build_request(&parameters);
 
-        let data = self.client.get(API::Spot(Spot::Klines), &request)?;
-        let parsed_data: Vec<Vec<Value>> = from_str(data.as_str())?;
+        let data: Vec<Vec<Value>> = self.client.get(API::Spot(Spot::Klines), &request)?;
 
         let klines = KlineSummaries::AllKlineSummaries(
-            parsed_data
-                .iter()
+            data.iter()
                 .map(|row| KlineSummary {
                     open_time: to_i64(&row[0]),
                     open: to_f64(&row[1]),

--- a/src/userstream.rs
+++ b/src/userstream.rs
@@ -1,7 +1,6 @@
 use crate::model::*;
 use crate::client::*;
 use crate::errors::*;
-use serde_json::from_str;
 use crate::api::API;
 use crate::api::Spot;
 
@@ -14,21 +13,15 @@ pub struct UserStream {
 impl UserStream {
     // User Stream
     pub fn start(&self) -> Result<UserDataStream> {
-        let data = self.client.post(API::Spot(Spot::UserDataStream))?;
-        let user_data_stream: UserDataStream = from_str(data.as_str())?;
-        Ok(user_data_stream)
+        self.client.post(API::Spot(Spot::UserDataStream))
     }
 
     // Current open orders on a symbol
     pub fn keep_alive(&self, listen_key: &str) -> Result<Success> {
-        let data = self.client.put(API::Spot(Spot::UserDataStream), listen_key)?;
-        let success: Success = from_str(data.as_str())?;
-        Ok(success)
+        self.client.put(API::Spot(Spot::UserDataStream), listen_key)
     }
 
     pub fn close(&self, listen_key: &str) -> Result<Success> {
-        let data = self.client.delete(API::Spot(Spot::UserDataStream), listen_key)?;
-        let success: Success = from_str(data.as_str())?;
-        Ok(success)
+        self.client.delete(API::Spot(Spot::UserDataStream), listen_key)
     }
 }

--- a/src/userstream.rs
+++ b/src/userstream.rs
@@ -2,8 +2,8 @@ use crate::model::*;
 use crate::client::*;
 use crate::errors::*;
 use serde_json::from_str;
-
-static USER_DATA_STREAM: &str = "/api/v3/userDataStream";
+use crate::api::API;
+use crate::api::Spot;
 
 #[derive(Clone)]
 pub struct UserStream {
@@ -14,26 +14,21 @@ pub struct UserStream {
 impl UserStream {
     // User Stream
     pub fn start(&self) -> Result<UserDataStream> {
-        let data = self.client.post(USER_DATA_STREAM)?;
+        let data = self.client.post(API::Spot(Spot::UserDataStream))?;
         let user_data_stream: UserDataStream = from_str(data.as_str())?;
-
         Ok(user_data_stream)
     }
 
     // Current open orders on a symbol
     pub fn keep_alive(&self, listen_key: &str) -> Result<Success> {
-        let data = self.client.put(USER_DATA_STREAM, listen_key)?;
-
+        let data = self.client.put(API::Spot(Spot::UserDataStream), listen_key)?;
         let success: Success = from_str(data.as_str())?;
-
         Ok(success)
     }
 
     pub fn close(&self, listen_key: &str) -> Result<Success> {
-        let data = self.client.delete(USER_DATA_STREAM, listen_key)?;
-
+        let data = self.client.delete(API::Spot(Spot::UserDataStream), listen_key)?;
         let success: Success = from_str(data.as_str())?;
-
         Ok(success)
     }
 }


### PR DESCRIPTION
In this PR I am including these functions:

 - stop_limit_sell_order
 - test_stop_limit_sell_order
 - stop_limit_buy_order
 - test_stop_limit_buy_order
 
 It also include more concise types like:

 - OrderType
   - Limit
   - Market
   - StopLossLimit
   
 - OrderSide
   - Buy
   - Sell
   
I also removed unnecessary conversion from `Data -> String -> JSON`, now the library converts `Data -> JSON` directly and the code got simplified.

I have updated some libraries, please let me known if you want to revert this change.
   
