### PR TITLE
Enable github action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Clippy
+      run: cargo clippy -- -D warnings
+    - name: Run tests
+      run: cargo test --verbose


### PR DESCRIPTION
Enable a simple github action flow, including clippy.

I didn't remove the existing travis config, so I guess they will run both now.