### PR TITLE
Fix critical typo in building request body

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -124,7 +124,7 @@ impl Client {
                 let mut signed_key = Hmac::<Sha256>::new_varkey(self.secret_key.as_bytes()).unwrap();
                 signed_key.update(request.as_bytes());
                 let signature = hex_encode(signed_key.finalize().into_bytes());
-                let request_body: String = format!("{:?}&signature={}", request, signature);
+                let request_body: String = format!("{}&signature={}", request, signature);
                 format!("{}{}?{}", self.host, String::from(endpoint), request_body)
             },
             None => {


### PR DESCRIPTION
I didn't see this in my review of @ppamorim 's PR, but found it while testing.

Using `{:?}` will put extra quotes around the printed string, which isn't correct.