### PR TITLE
Feature/add initial tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,5 @@ vendored-tls = ["reqwest/native-tls-vendored", "tungstenite/tls-vendored"]
 
 [dev-dependencies]
 csv ="1.1.5"
+mockito = "0.30.0"
+env_logger = "0.8.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -124,7 +124,7 @@ impl Client {
                 let mut signed_key = Hmac::<Sha256>::new_varkey(self.secret_key.as_bytes()).unwrap();
                 signed_key.update(request.as_bytes());
                 let signature = hex_encode(signed_key.finalize().into_bytes());
-                let request_body: String = format!("{:?}&signature={}", request, signature);
+                let request_body: String = format!("{}&signature={}", request, signature);
                 format!("{}{}?{}", self.host, String::from(endpoint), request_body)
             },
             None => {

--- a/tests/account_tests.rs
+++ b/tests/account_tests.rs
@@ -1,0 +1,32 @@
+use binance::api::*;
+use binance::config::*;
+use binance::account::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::{mock, Matcher};
+
+    #[test]
+    fn test_order_market_buy_using_quote_quantity() {
+        let mock_exchange_info = mock("POST", "/api/v3/order")
+            .with_header("content-type", "application/json;charset=UTF-8")
+            .match_query(Matcher::Regex("quoteOrderQty=0.002&recvWindow=1234&side=BUY&symbol=BNBBTC&timestamp=\\d+&type=MARKET&signature=.*".into()))
+            .with_body_from_file("tests/mocks/account/order_market_buy_using_quote_quantity.json")
+            .create();
+
+        let config = Config::default()
+            .set_rest_api_endpoint(mockito::server_url())
+            .set_recv_window(1234);
+        let account: Account = Binance::new_with_config(None, None, &config);
+        let _ = env_logger::try_init();
+        match account.market_buy_using_quote_quantity("BNBBTC", 0.002) {
+            Ok(answer) => {
+                assert!(answer.order_id == 1);
+            }
+            Err(e) => panic!("Error: {}", e),
+        }
+
+        mock_exchange_info.assert();
+    }
+}

--- a/tests/general_tests.rs
+++ b/tests/general_tests.rs
@@ -1,0 +1,29 @@
+use binance::api::*;
+use binance::config::*;
+use binance::general::*;
+// use crate::account::*;
+// use crate::market::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::mock;
+    // use binance::config::Config;
+    // use binance::general::General;
+
+    #[test]
+    fn exchange_info() {
+        let mock_exchange_info = mock("GET", "/api/v3/exchangeInfo")
+            .with_header("content-type", "application/json;charset=UTF-8")
+            .with_body_from_file("tests/mocks/general/exchangeInfo.json")
+            .create();
+
+        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let general: General = Binance::new_with_config(None, None, &config);
+
+        let exchange_info = general.exchange_info().unwrap();
+        mock_exchange_info.assert();
+
+        assert!(exchange_info.symbols.len() > 1);
+    }
+}

--- a/tests/mocks/account/order_market_buy_using_quote_quantity.json
+++ b/tests/mocks/account/order_market_buy_using_quote_quantity.json
@@ -1,0 +1,23 @@
+{
+		"symbol": "BNBBTC",
+		"orderId": 1,
+		"clientOrderId": "myOrder1",
+		"transactTime": 1499827319559,
+		"price": "0.00007456",
+		"origQty": "1.00",
+		"executedQty": "2.682403433476395",
+		"cummulativeQuoteQty": "0.0002",
+		"status": "FILLED",
+		"timeInForce": "GTC",
+		"type": "MARKET",
+		"side": "BUY",
+        "fills": [
+			{
+				"price":"0.00007456",
+				"qty":"2.682403433476395",
+				"commission":"0.00332384",
+				"commissionAsset":"BNB",
+				"tradeId":1566397
+			}
+        ]
+}

--- a/tests/mocks/general/exchangeInfo.json
+++ b/tests/mocks/general/exchangeInfo.json
@@ -1,0 +1,240 @@
+{
+  "timezone": "UTC",
+  "serverTime": 1614694549948,
+  "rateLimits": [
+    {
+      "rateLimitType": "REQUEST_WEIGHT",
+      "interval": "MINUTE",
+      "intervalNum": 1,
+      "limit": 1200
+    },
+    {
+      "rateLimitType": "ORDERS",
+      "interval": "SECOND",
+      "intervalNum": 10,
+      "limit": 100
+    },
+    {
+      "rateLimitType": "ORDERS",
+      "interval": "DAY",
+      "intervalNum": 1,
+      "limit": 200000
+    }
+  ],
+  "exchangeFilters": [],
+  "symbols": [
+    {
+      "symbol": "ETHBTC",
+      "status": "TRADING",
+      "baseAsset": "ETH",
+      "baseAssetPrecision": 8,
+      "quoteAsset": "BTC",
+      "quotePrecision": 8,
+      "quoteAssetPrecision": 8,
+      "baseCommissionPrecision": 8,
+      "quoteCommissionPrecision": 8,
+      "orderTypes": [
+        "LIMIT",
+        "LIMIT_MAKER",
+        "MARKET",
+        "STOP_LOSS_LIMIT",
+        "TAKE_PROFIT_LIMIT"
+      ],
+      "icebergAllowed": true,
+      "ocoAllowed": true,
+      "quoteOrderQtyMarketAllowed": true,
+      "isSpotTradingAllowed": true,
+      "isMarginTradingAllowed": true,
+      "filters": [
+        {
+          "filterType": "PRICE_FILTER",
+          "minPrice": "0.00000100",
+          "maxPrice": "100000.00000000",
+          "tickSize": "0.00000100"
+        },
+        {
+          "filterType": "PERCENT_PRICE",
+          "multiplierUp": "5",
+          "multiplierDown": "0.2",
+          "avgPriceMins": 5
+        },
+        {
+          "filterType": "LOT_SIZE",
+          "minQty": "0.00100000",
+          "maxQty": "100000.00000000",
+          "stepSize": "0.00100000"
+        },
+        {
+          "filterType": "MIN_NOTIONAL",
+          "minNotional": "0.00010000",
+          "applyToMarket": true,
+          "avgPriceMins": 5
+        },
+        {
+          "filterType": "ICEBERG_PARTS",
+          "limit": 10
+        },
+        {
+          "filterType": "MARKET_LOT_SIZE",
+          "minQty": "0.00000000",
+          "maxQty": "2456.75855038",
+          "stepSize": "0.00000000"
+        },
+        {
+          "filterType": "MAX_NUM_ORDERS",
+          "maxNumOrders": 200
+        },
+        {
+          "filterType": "MAX_NUM_ALGO_ORDERS",
+          "maxNumAlgoOrders": 5
+        }
+      ],
+      "permissions": [
+        "SPOT",
+        "MARGIN"
+      ]
+    },
+    {
+      "symbol": "LTCBTC",
+      "status": "TRADING",
+      "baseAsset": "LTC",
+      "baseAssetPrecision": 8,
+      "quoteAsset": "BTC",
+      "quotePrecision": 8,
+      "quoteAssetPrecision": 8,
+      "baseCommissionPrecision": 8,
+      "quoteCommissionPrecision": 8,
+      "orderTypes": [
+        "LIMIT",
+        "LIMIT_MAKER",
+        "MARKET",
+        "STOP_LOSS_LIMIT",
+        "TAKE_PROFIT_LIMIT"
+      ],
+      "icebergAllowed": true,
+      "ocoAllowed": true,
+      "quoteOrderQtyMarketAllowed": true,
+      "isSpotTradingAllowed": true,
+      "isMarginTradingAllowed": true,
+      "filters": [
+        {
+          "filterType": "PRICE_FILTER",
+          "minPrice": "0.00000100",
+          "maxPrice": "100000.00000000",
+          "tickSize": "0.00000100"
+        },
+        {
+          "filterType": "PERCENT_PRICE",
+          "multiplierUp": "5",
+          "multiplierDown": "0.2",
+          "avgPriceMins": 5
+        },
+        {
+          "filterType": "LOT_SIZE",
+          "minQty": "0.01000000",
+          "maxQty": "100000.00000000",
+          "stepSize": "0.01000000"
+        },
+        {
+          "filterType": "MIN_NOTIONAL",
+          "minNotional": "0.00010000",
+          "applyToMarket": true,
+          "avgPriceMins": 5
+        },
+        {
+          "filterType": "ICEBERG_PARTS",
+          "limit": 10
+        },
+        {
+          "filterType": "MARKET_LOT_SIZE",
+          "minQty": "0.00000000",
+          "maxQty": "13630.19142460",
+          "stepSize": "0.00000000"
+        },
+        {
+          "filterType": "MAX_NUM_ORDERS",
+          "maxNumOrders": 200
+        },
+        {
+          "filterType": "MAX_NUM_ALGO_ORDERS",
+          "maxNumAlgoOrders": 5
+        }
+      ],
+      "permissions": [
+        "SPOT",
+        "MARGIN"
+      ]
+    },
+    {
+      "symbol": "BNBBTC",
+      "status": "TRADING",
+      "baseAsset": "BNB",
+      "baseAssetPrecision": 8,
+      "quoteAsset": "BTC",
+      "quotePrecision": 8,
+      "quoteAssetPrecision": 8,
+      "baseCommissionPrecision": 8,
+      "quoteCommissionPrecision": 8,
+      "orderTypes": [
+        "LIMIT",
+        "LIMIT_MAKER",
+        "MARKET",
+        "STOP_LOSS_LIMIT",
+        "TAKE_PROFIT_LIMIT"
+      ],
+      "icebergAllowed": true,
+      "ocoAllowed": true,
+      "quoteOrderQtyMarketAllowed": true,
+      "isSpotTradingAllowed": true,
+      "isMarginTradingAllowed": true,
+      "filters": [
+        {
+          "filterType": "PRICE_FILTER",
+          "minPrice": "0.00000010",
+          "maxPrice": "100000.00000000",
+          "tickSize": "0.00000010"
+        },
+        {
+          "filterType": "PERCENT_PRICE",
+          "multiplierUp": "5",
+          "multiplierDown": "0.2",
+          "avgPriceMins": 5
+        },
+        {
+          "filterType": "LOT_SIZE",
+          "minQty": "0.01000000",
+          "maxQty": "100000.00000000",
+          "stepSize": "0.01000000"
+        },
+        {
+          "filterType": "MIN_NOTIONAL",
+          "minNotional": "0.00010000",
+          "applyToMarket": true,
+          "avgPriceMins": 5
+        },
+        {
+          "filterType": "ICEBERG_PARTS",
+          "limit": 10
+        },
+        {
+          "filterType": "MARKET_LOT_SIZE",
+          "minQty": "0.00000000",
+          "maxQty": "8528.32329395",
+          "stepSize": "0.00000000"
+        },
+        {
+          "filterType": "MAX_NUM_ORDERS",
+          "maxNumOrders": 200
+        },
+        {
+          "filterType": "MAX_NUM_ALGO_ORDERS",
+          "maxNumAlgoOrders": 5
+        }
+      ],
+      "permissions": [
+        "SPOT",
+        "MARGIN"
+      ]
+    }
+ ]
+}


### PR DESCRIPTION
Initial set of end-to-end tests, testing only 2 possible end points. More checks on the results can be added at a later stage as well.

(has https://github.com/wisespace-io/binance-rs/pull/90 already integrated).