### PR TITLE
Fix MinNotional filter.

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -67,8 +67,9 @@ pub enum Filters {
     #[serde(rename = "MIN_NOTIONAL")]
     #[serde(rename_all = "camelCase")]
     MinNotional {
-        min_notional: String,
-        apply_to_market: bool,
+        notional: Option<String>,
+        min_notional: Option<String>,
+        apply_to_market: Option<bool>,
         avg_price_mins: Option<f64>,
     },
     #[serde(rename = "ICEBERG_PARTS")]


### PR DESCRIPTION
For Futures https://fapi.binance.com/fapi/v1/exchangeInfo response is
{"filterType":"MIN_NOTIONAL","notional":"5"}

For Spot https://api.binance.com/api/v1/exchangeInfo response is
{"filterType":"MIN_NOTIONAL","minNotional":"0.00010000","applyToMarket":true,"avgPriceMins":5}