### PR TITLE
Fixing typo for Spot::Ticker24hr in api.rs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -84,7 +84,7 @@ impl From<API> for String {
                     Spot::AggTrades => "/api/v3/aggTrades",
                     Spot::Klines => "/api/v3/klines",
                     Spot::AvgPrice => "/api/v3/avgPrice",
-                    Spot::Ticker24hr => "/api/v3/ticker/24h",
+                    Spot::Ticker24hr => "/api/v3/ticker/24hr",
                     Spot::Price => "/api/v3/ticker/price",
                     Spot::BookTicker => "/api/v3/ticker/bookTicker",
                     Spot::Order => "/api/v3/order",

--- a/tests/market_tests.rs
+++ b/tests/market_tests.rs
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn get_24h_price_stats() {
 
-        let mock_get_24h_price_stats = mock("GET", "/api/v3/ticker/24h")
+        let mock_get_24h_price_stats = mock("GET", "/api/v3/ticker/24hr")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("symbol=BNBBTC".into()))
             .with_body_from_file("tests/mocks/market/get_24h_price_stats.json")

--- a/tests/market_tests.rs
+++ b/tests/market_tests.rs
@@ -214,7 +214,7 @@ mod tests {
     #[test]
     fn get_all_24h_price_stats() {
 
-        let mock_get_all_24h_price_stats = mock("GET", "/api/v3/ticker/24h")
+        let mock_get_all_24h_price_stats = mock("GET", "/api/v3/ticker/24hr")
             .with_header("content-type", "application/json;charset=UTF-8")
             .with_body_from_file("tests/mocks/market/get_all_24h_price_stats.json")
             .create();


### PR DESCRIPTION
Added "r" letter at the end of api address. With this fix, it is not giving 404 error anymore.