### PR TITLE
Add pu field to DepthOrderBookEvent

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -761,6 +761,9 @@ pub struct DepthOrderBookEvent {
     #[serde(rename = "u")]
     pub final_update_id: u64,
 
+    #[serde(rename = "pu")]
+    pub previous_final_update_id: u64,
+
     #[serde(rename = "b")]
     pub bids: Vec<Bids>,
 


### PR DESCRIPTION
This field is required to be checked when one wants to have a local order book.