### PR TITLE
fix: fix testenet api endpoints

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,9 +24,9 @@ impl Config {
 
     pub fn testnet() -> Config {
         Config::default()
-            .set_rest_api_endpoint("https://testnet.binance.vision/api")
+            .set_rest_api_endpoint("https://testnet.binance.vision")
             .set_ws_endpoint("wss://testnet.binance.vision/ws")
-            .set_futures_rest_api_endpoint("https://testnet.binancefuture.com/api")
+            .set_futures_rest_api_endpoint("https://testnet.binancefuture.com")
             .set_futures_ws_endpoint("https://testnet.binancefuture.com/ws")
     }
 


### PR DESCRIPTION
if the testnet config is used, we get the following error as we have repeated `api` in the URL:

```
2021-05-22 10:15:58,765 DEBUG [reqwest::async_impl::client] response '404 Not Found' for https://testnet.binance.vision/api/api/v3/account?recvWindow=5000&timestamp=1621671357714...
```