### PR TITLE
feat: add client id for custom order

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -20,6 +20,7 @@ struct OrderRequest {
     pub order_side: OrderSide,
     pub order_type: OrderType,
     pub time_in_force: TimeInForce,
+    pub new_client_order_id: Option<String>,
 }
 
 struct OrderQuoteQuantityRequest {
@@ -29,6 +30,7 @@ struct OrderQuoteQuantityRequest {
     pub order_side: OrderSide,
     pub order_type: OrderType,
     pub time_in_force: TimeInForce,
+    pub new_client_order_id: Option<String>,
 }
 
 pub enum OrderType {
@@ -179,6 +181,7 @@ impl Account {
             order_side: OrderSide::Buy,
             order_type: OrderType::Limit,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -201,6 +204,7 @@ impl Account {
             order_side: OrderSide::Buy,
             order_type: OrderType::Limit,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -223,6 +227,7 @@ impl Account {
             order_side: OrderSide::Sell,
             order_type: OrderType::Limit,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -245,6 +250,7 @@ impl Account {
             order_side: OrderSide::Sell,
             order_type: OrderType::Limit,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -267,6 +273,7 @@ impl Account {
             order_side: OrderSide::Buy,
             order_type: OrderType::Market,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -289,6 +296,7 @@ impl Account {
             order_side: OrderSide::Buy,
             order_type: OrderType::Market,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -312,6 +320,7 @@ impl Account {
             order_side: OrderSide::Buy,
             order_type: OrderType::Market,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -335,6 +344,7 @@ impl Account {
             order_side: OrderSide::Buy,
             order_type: OrderType::Market,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_quote_quantity_order(buy);
         let request = build_signed_request(order, self.recv_window)?;
@@ -357,6 +367,7 @@ impl Account {
             order_side: OrderSide::Sell,
             order_type: OrderType::Market,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -379,6 +390,7 @@ impl Account {
             order_side: OrderSide::Sell,
             order_type: OrderType::Market,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -402,6 +414,7 @@ impl Account {
             order_side: OrderSide::Sell,
             order_type: OrderType::Market,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -425,6 +438,7 @@ impl Account {
             order_side: OrderSide::Sell,
             order_type: OrderType::Market,
             time_in_force: TimeInForce::GTC,
+            new_client_order_id: None,
         };
         let order = self.build_quote_quantity_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -433,9 +447,9 @@ impl Account {
         .map(|_|())
     }
 
-    /// Create a stop limit buy order for the given symbol, price and stop price. 
+    /// Create a stop limit buy order for the given symbol, price and stop price.
     /// Returning a `Transaction` value with the same parameters sent on the order.
-    /// 
+    ///
     ///```no_run
     /// use binance::api::Binance;
     /// use binance::account::*;
@@ -467,17 +481,18 @@ impl Account {
             order_side: OrderSide::Buy,
             order_type: OrderType::StopLossLimit,
             time_in_force,
+            new_client_order_id: None,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
         self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
-    /// Create a stop limit buy test order for the given symbol, price and stop price. 
+    /// Create a stop limit buy test order for the given symbol, price and stop price.
     /// Returning a `Transaction` value with the same parameters sent on the order.
-    /// 
+    ///
     /// This order is sandboxed: it is validated, but not sent to the matching engine.
-    /// 
+    ///
     ///```no_run
     /// use binance::api::Binance;
     /// use binance::account::*;
@@ -509,6 +524,7 @@ impl Account {
             order_side: OrderSide::Buy,
             order_type: OrderType::StopLossLimit,
             time_in_force,
+            new_client_order_id: None,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -517,9 +533,9 @@ impl Account {
             .map(|_|())
     }
 
-    /// Create a stop limit sell order for the given symbol, price and stop price. 
+    /// Create a stop limit sell order for the given symbol, price and stop price.
     /// Returning a `Transaction` value with the same parameters sent on the order.
-    /// 
+    ///
     ///```no_run
     /// use binance::api::Binance;
     /// use binance::account::*;
@@ -551,17 +567,18 @@ impl Account {
             order_side: OrderSide::Sell,
             order_type: OrderType::StopLossLimit,
             time_in_force,
+            new_client_order_id: None,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
         self.client.post_signed(API::Spot(Spot::Order), request)
     }
 
-    /// Create a stop limit sell order for the given symbol, price and stop price. 
+    /// Create a stop limit sell order for the given symbol, price and stop price.
     /// Returning a `Transaction` value with the same parameters sent on the order.
-    /// 
+    ///
     /// This order is sandboxed: it is validated, but not sent to the matching engine.
-    /// 
+    ///
     ///```no_run
     /// use binance::api::Binance;
     /// use binance::account::*;
@@ -593,6 +610,7 @@ impl Account {
             order_side: OrderSide::Sell,
             order_type: OrderType::StopLossLimit,
             time_in_force,
+            new_client_order_id: None,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -600,9 +618,9 @@ impl Account {
             .post_signed::<Empty>(API::Spot(Spot::OrderTest), request)
             .map(|_|())
     }
-    
+
     /// Place a custom order
-    #[allow(clippy::too_many_arguments)] 
+    #[allow(clippy::too_many_arguments)]
     pub fn custom_order<S, F>(
         &self,
         symbol: S,
@@ -612,6 +630,7 @@ impl Account {
         order_side: OrderSide,
         order_type: OrderType,
         time_in_force: TimeInForce,
+        new_client_order_id : Option<String>,
     ) -> Result<Transaction>
     where
         S: Into<String>,
@@ -625,6 +644,7 @@ impl Account {
             order_side,
             order_type,
             time_in_force,
+            new_client_order_id,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -634,7 +654,7 @@ impl Account {
     /// Place a test custom order
     ///
     /// This order is sandboxed: it is validated, but not sent to the matching engine.
-    #[allow(clippy::too_many_arguments)] 
+    #[allow(clippy::too_many_arguments)]
     pub fn test_custom_order<S, F>(
         &self,
         symbol: S,
@@ -644,6 +664,7 @@ impl Account {
         order_side: OrderSide,
         order_type: OrderType,
         time_in_force: TimeInForce,
+        new_client_order_id : Option<String>,
     ) -> Result<()>
     where
         S: Into<String>,
@@ -657,6 +678,7 @@ impl Account {
             order_side,
             order_type,
             time_in_force,
+            new_client_order_id,
         };
         let order = self.build_order(sell);
         let request = build_signed_request(order, self.recv_window)?;
@@ -723,6 +745,10 @@ impl Account {
             order_parameters.insert("timeInForce".into(), order.time_in_force.into());
         }
 
+        if let Some(client_order_id) = order.new_client_order_id {
+            order_parameters.insert("newClientOrderId".into(), client_order_id);
+        }
+
         order_parameters
     }
 
@@ -739,6 +765,10 @@ impl Account {
         if order.price != 0.0 {
             order_parameters.insert("price".into(), order.price.to_string());
             order_parameters.insert("timeInForce".into(), order.time_in_force.into());
+        }
+
+        if let Some(client_order_id) = order.new_client_order_id {
+            order_parameters.insert("newClientOrderId".into(), client_order_id);
         }
 
         order_parameters

--- a/tests/account_tests.rs
+++ b/tests/account_tests.rs
@@ -671,7 +671,7 @@ mod tests {
 
         let mock_custom_order = mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=MARKET".into()))
+            .match_query(Matcher::Regex("newClientOrderId=6gCrw2kRUAF9CvJDGP16IP&price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=MARKET".into()))
             .with_body_from_file("tests/mocks/account/stop_limit_sell.json")
             .create();
 
@@ -681,7 +681,7 @@ mod tests {
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
         let transaction: Transaction = account.custom_order(
-            "LTCBTC", 1, 0.1, None, OrderSide::Buy, OrderType::Market, TimeInForce::GTC).unwrap();
+            "LTCBTC", 1, 0.1, None, OrderSide::Buy, OrderType::Market, TimeInForce::GTC, Some("6gCrw2kRUAF9CvJDGP16IP".into())).unwrap();
 
         mock_custom_order.assert();
 
@@ -717,7 +717,7 @@ mod tests {
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
         let _ = account.test_custom_order(
-            "LTCBTC", 1, 0.1, None, OrderSide::Buy, OrderType::Market, TimeInForce::GTC).unwrap();
+            "LTCBTC", 1, 0.1, None, OrderSide::Buy, OrderType::Market, TimeInForce::GTC, None).unwrap();
 
         mock_test_custom_order.assert();
 


### PR DESCRIPTION
add the possibility to provide a client's order ID in the custom mode