### PR TITLE
Fix bug in futures market_buy and market_sell

### DIFF
--- a/src/futures/account.rs
+++ b/src/futures/account.rs
@@ -191,7 +191,7 @@ impl FuturesAccount {
     }
 
     // Place a MARKET order - SELL
-    pub fn market_sell<S, F>(&self, symbol: S, qty: F, time_in_force: TimeInForce) -> Result<Transaction>
+    pub fn market_sell<S, F>(&self, symbol: S, qty: F) -> Result<Transaction>
     where
         S: Into<String>,
         F: Into<f64>,
@@ -201,7 +201,7 @@ impl FuturesAccount {
             side: OrderSide::Sell,
             position_side: None,
             order_type: OrderType::Market,
-            time_in_force: Some(time_in_force),
+            time_in_force: None,
             qty: Some(qty.into()),
             reduce_only: None,
             price: None,

--- a/src/futures/account.rs
+++ b/src/futures/account.rs
@@ -164,7 +164,7 @@ impl FuturesAccount {
     }
 
     // Place a MARKET order - BUY
-    pub fn market_buy<S, F>(&self, symbol: S, qty: F, time_in_force: TimeInForce) -> Result<Transaction>
+    pub fn market_buy<S, F>(&self, symbol: S, qty: F) -> Result<Transaction>
     where
         S: Into<String>,
         F: Into<f64>,
@@ -174,7 +174,7 @@ impl FuturesAccount {
             side: OrderSide::Buy,
             position_side: None,
             order_type: OrderType::Market,
-            time_in_force: Some(time_in_force),
+            time_in_force: None,
             qty: Some(qty.into()),
             reduce_only: None,
             price: None,


### PR DESCRIPTION
Apparently Binance does not allow the timeInForce parameter for market orders (in hindsight it does not make much sense to have it there anyway), so I removed it.
The current implementation will always error with:
`Error(BinanceError(BinanceContentError { code: -1106, msg: "Parameter \'timeInForce\' sent when not required.", extra: {} }), State { next_error: None, backtrace: InternalBacktrace }`

This time I actually tested it and it works now.