### PR TITLE
Change string_or_float to accept INF

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -797,7 +797,13 @@ pub(crate) mod string_or_float {
         }
 
         match StringOrFloat::deserialize(deserializer)? {
-            StringOrFloat::String(s) => s.parse().map_err(de::Error::custom),
+            StringOrFloat::String(s) => {
+                if s == "INF" {
+                    Ok(f64::INFINITY)
+                } else {
+                    s.parse().map_err(de::Error::custom)
+                }
+            },
             StringOrFloat::Float(i) => Ok(i),
         }
     }


### PR DESCRIPTION
Binance is using "INF" as a string for infinity. For example, when calling change_initial_leverage with a leverage of 1, the response will contain a max_notional_value of "INF".
The current version fails with a decode error, so I added a check to the decoder.