### PR TITLE
Add futures websockets

### DIFF
--- a/examples/binance_futures_websockets.rs
+++ b/examples/binance_futures_websockets.rs
@@ -1,0 +1,59 @@
+use binance::api::*;
+use binance::websockets::*;
+// use binance::userstream::*;
+use binance::futures::websockets::*;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+fn main() {
+    // user_stream();
+    // user_stream_websocket();
+    market_websocket();
+    //kline_websocket();
+    //all_trades_websocket();
+    //last_price_for_one_symbol();
+    // multiple_streams();
+}
+
+
+fn market_websocket() {
+    let keep_running = AtomicBool::new(true);
+    let agg_trade: String = String::from("btcusd_210924@bookTicker");
+    // let agg_trade: String = String::from("btcusd_200925@aggTrade");
+
+    let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(|event: WebsocketEvent| {
+        println!("{:?}", event);
+        match event {
+            WebsocketEvent::Trade(trade) => {
+                println!(
+                    "Symbol: {}, price: {}, qty: {}",
+                    trade.symbol, trade.price, trade.qty
+                );
+            }
+            WebsocketEvent::DepthOrderBook(depth_order_book) => {
+                println!(
+                    "Symbol: {}, Bids: {:?}, Ask: {:?}",
+                    depth_order_book.symbol, depth_order_book.bids, depth_order_book.asks
+                );
+            }
+            WebsocketEvent::OrderBook(order_book) => {
+                println!(
+                    "last_update_id: {}, Bids: {:?}, Ask: {:?}",
+                    order_book.last_update_id, order_book.bids, order_book.asks
+                );
+            }
+            _ => (),
+        };
+
+        Ok(())
+    });
+
+    let streams = vec![String::from("btcusd_210924@bookTicker")];
+
+    web_socket.connect(&agg_trade).unwrap(); // check error
+    // web_socket.connect_multiple_streams(&streams).unwrap(); // check error
+    if let Err(e) = web_socket.event_loop(&keep_running) {
+        println!("Error: {}", e);
+    }
+    web_socket.disconnect().unwrap();
+    println!("disconnected");
+}

--- a/examples/binance_futures_websockets.rs
+++ b/examples/binance_futures_websockets.rs
@@ -17,6 +17,7 @@ fn main() {
 
 fn market_websocket() {
     let keep_running = AtomicBool::new(true);
+
     let agg_trade: String = String::from("btcusd_210924@bookTicker");
     // let agg_trade: String = String::from("btcusd_200925@aggTrade");
 
@@ -28,18 +29,21 @@ fn market_websocket() {
                     "Symbol: {}, price: {}, qty: {}",
                     trade.symbol, trade.price, trade.qty
                 );
+                keep_running.swap(false, Ordering::Relaxed);
             }
             WebsocketEvent::DepthOrderBook(depth_order_book) => {
                 println!(
                     "Symbol: {}, Bids: {:?}, Ask: {:?}",
                     depth_order_book.symbol, depth_order_book.bids, depth_order_book.asks
                 );
+                keep_running.swap(false, Ordering::Relaxed);
             }
             WebsocketEvent::OrderBook(order_book) => {
                 println!(
                     "last_update_id: {}, Bids: {:?}, Ask: {:?}",
                     order_book.last_update_id, order_book.bids, order_book.asks
                 );
+                keep_running.swap(false, Ordering::Relaxed);
             }
             _ => (),
         };
@@ -47,13 +51,12 @@ fn market_websocket() {
         Ok(())
     });
 
-    let streams = vec![String::from("btcusd_210924@bookTicker")];
-
-    web_socket.connect(&agg_trade).unwrap(); // check error
-    // web_socket.connect_multiple_streams(&streams).unwrap(); // check error
+    web_socket.connect(FuturesMarket::COINM, &agg_trade).unwrap(); // check error
     if let Err(e) = web_socket.event_loop(&keep_running) {
         println!("Error: {}", e);
     }
     web_socket.disconnect().unwrap();
     println!("disconnected");
 }
+
+

--- a/examples/binance_futures_websockets.rs
+++ b/examples/binance_futures_websockets.rs
@@ -2,18 +2,15 @@ use binance::futures::websockets::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 fn main() {
-    // user_stream();
-    // user_stream_websocket();
     market_websocket();
-    //kline_websocket();
-    //all_trades_websocket();
-    //last_price_for_one_symbol();
-    // multiple_streams();
 }
 
 fn market_websocket() {
+    // Example to show the future market websockets. It will print one event for each
+    // endpoint and continue to the next.
+
     let keep_running = AtomicBool::new(true);
-    let stream_examples_usd = vec![
+    let stream_examples_usd_m = vec![
         // taken from https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams
         String::from("btcusdt@aggTrade"),  // <symbol>@aggTrade
         String::from("btcusdt@markPrice"), // <symbol>@markPrice OR <symbol>@markPrice@1s
@@ -33,28 +30,28 @@ fn market_websocket() {
         String::from("btcusdt@depth@100ms"), // <symbol>@depth OR <symbol>@depth@500ms OR <symbol>@depth@100ms
     ];
 
-    let _stream_examples_coin = vec![
+    let stream_examples_coin_m = vec![
         // taken from https://binance-docs.github.io/apidocs/delivery/en/#websocket-market-streams
-        //ok
-        // String::from("btcusd_210924@aggTrade"), // <symbol>@aggTrade
-        //ok
-        // String::from("btcusd@indexPrice@1s"),                     //<pair>@indexPrice OR <pair>@indexPrice@1s
 
-        // onbekend
+        // A possible symbol is btcusd_210924. This needs updates if the current date
+        // is greater than 2021-09-24. It'd be nice to make this symbol automatically
+        // generated, or find a <symbol> that always works.
+        String::from("btcusd_210924@aggTrade"), // <symbol>@aggTrade
+        String::from("btcusd@indexPrice@1s"),   //<pair>@indexPrice OR <pair>@indexPrice@1s
         String::from("btcusd_210924@markPrice"), // <symbol>@markPrice OR <symbol>@markPrice@1s
-        String::from("btcusd@markPrice"), // <pair>@markPrice OR <pair>@markPrice@1s
-
-        // ok
+        String::from("btcusd@markPrice"),       // <pair>@markPrice OR <pair>@markPrice@1s
         String::from("btcusd_210924@kline_1m"), // <symbol>@kline_<interval>
-        String::from("btcusd_210924@continuousKline_1m"), // <pair>_<contractType>@continuousKline_<interval>
-        String::from("btcusd_210924@indexPriceKline_1m"), // <pair>@indexPriceKline_<interval>
-        String::from("btcusd_210924@markPriceKline_1m"),  // <symbol>@markPriceKline_<interval>
-        String::from("btcusd_210924@miniTicker"),         // <symbol>@miniTicker
+        String::from("btcusd_next_quarter@continuousKline_1m"), // <pair>_<contractType>@continuousKline_<interval>
+        String::from("btcusd@indexPriceKline_1m"),              // <pair>@indexPriceKline_<interval>
+        String::from("btcusd_210924@markPriceKline_1m"), // <symbol>@markPriceKline_<interval>
+        String::from("btcusd_210924@miniTicker"),        // <symbol>@miniTicker
         String::from("!miniTicker@arr"),
         String::from("btcusd_210924@ticker"), // <symbol>@ticker
         String::from("!ticker@arr"),
         String::from("btcusd_210924@bookTicker"), // <symbol>@bookTicker
         String::from("!bookTicker"),
+        // forceOrder can take a while before a message comes in, since
+        // it depends on when a position is liquidated
         String::from("btcusd_210924@forceOrder"), // <symbol>@forceOrder
         String::from("!forceOrder@arr"),
         String::from("btcusd_210924@depth20@100ms"), // <symbol>@depth<levels> OR <symbol>@depth<levels>@500ms OR <symbol>@depth<levels>@100ms.
@@ -62,54 +59,38 @@ fn market_websocket() {
     ];
 
     let callback_fn = |event: FuturesWebsocketEvent| {
+        // once a FuturesWebsocketEvent is recevied, we print it
+        // and stop this socket, so the example will continue to the next one
+        //
+        // in case an event comes in that doesn't properly serialize to
+        // a FuturesWebsocketEvent, the web socket loop will keep running
         println!("{:?}\n", event);
         keep_running.swap(false, Ordering::Relaxed);
-        match event {
-            FuturesWebsocketEvent::Trade(trade) => {
-                println!(
-                    "Symbol: {}, price: {}, qty: {}",
-                    trade.symbol, trade.price, trade.qty
-                );
-                keep_running.swap(false, Ordering::Relaxed);
-            }
-            FuturesWebsocketEvent::DepthOrderBook(depth_order_book) => {
-                println!(
-                    "Symbol: {}, Bids: {:?}, Ask: {:?}",
-                    depth_order_book.symbol, depth_order_book.bids, depth_order_book.asks
-                );
-                keep_running.swap(false, Ordering::Relaxed);
-            }
-            FuturesWebsocketEvent::OrderBook(order_book) => {
-                println!(
-                    "last_update_id: {}, Bids: {:?}, Ask: {:?}",
-                    order_book.last_update_id, order_book.bids, order_book.asks
-                );
-                keep_running.swap(false, Ordering::Relaxed);
-            }
-            _ => (),
-        };
 
         Ok(())
     };
-    for stream_example in stream_examples_usd {
+
+    // USD-M futures examples
+    for stream_example in stream_examples_usd_m {
         keep_running.swap(true, Ordering::Relaxed);
 
         let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(callback_fn);
         web_socket
-            .connect(FuturesMarket::USD, &stream_example)
+            .connect(FuturesMarket::USDM, &stream_example)
             .unwrap();
         web_socket.event_loop(&keep_running).unwrap();
         web_socket.disconnect().unwrap();
     }
 
-    // for stream_example in stream_examples_coin {
-    //     keep_running.swap(true, Ordering::Relaxed);
+    // COIN-M futures examples
+    for stream_example in stream_examples_coin_m {
+        keep_running.swap(true, Ordering::Relaxed);
 
-    //     let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(callback_fn);
-    //     web_socket
-    //         .connect(FuturesMarket::COINM, &stream_example)
-    //         .unwrap();
-    //     web_socket.event_loop(&keep_running).unwrap();
-    //     web_socket.disconnect().unwrap();
-    // }
+        let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(callback_fn);
+        web_socket
+            .connect(FuturesMarket::COINM, &stream_example)
+            .unwrap();
+        web_socket.event_loop(&keep_running).unwrap();
+        web_socket.disconnect().unwrap();
+    }
 }

--- a/examples/binance_futures_websockets.rs
+++ b/examples/binance_futures_websockets.rs
@@ -1,6 +1,4 @@
-use binance::websockets::*;
 use binance::futures::websockets::*;
-use tungstenite::stream;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 fn main() {
@@ -15,73 +13,73 @@ fn main() {
 
 fn market_websocket() {
     let keep_running = AtomicBool::new(true);
-    let stream_examples_USD = vec![
-        // works
-        String::from("btcusdt@aggTrade"),               // <symbol>@aggTrade
-        
-        // does not work
-        // String::from("btcusdt@indexPrice@1s"),                     //<pair>@indexPrice OR <pair>@indexPrice@1s
-        
-        // works
+    let stream_examples_usd = vec![
+        // taken from https://binance-docs.github.io/apidocs/futures/en/#websocket-market-streams
+        String::from("btcusdt@aggTrade"),  // <symbol>@aggTrade
         String::from("btcusdt@markPrice"), // <symbol>@markPrice OR <symbol>@markPrice@1s
-
-        // String::from("btcusd_210924@markPrice"), // <pair>@markPrice OR <pair>@markPrice@1s
-
-        // String::from("btcusdt@kline_1m"), // <symbol>@kline_<interval>
-
-        // String::from("btcusd_210924@continuousKline_1m"), // <pair>_<contractType>@continuousKline_<interval> e.g. "btcusd_next_quarter@continuousKline_1m"
-        // String::from("btcusd_210924@indexPriceKline_1m"), // <pair>@indexPriceKline_<interval> e.g. "btcusd@indexPriceKline_1m"
-        // String::from("btcusd_210924@markPriceKline_1m"), // <symbol>@markPriceKline_<interval> e.g. e.g. "btcusd_200626@markPriceKline_1m"
-        // String::from("btcusdt@miniTicker"), // <symbol>@miniTicker
-        // String::from("!miniTicker@arr"),
-        // String::from("btcusdt@ticker"), // <symbol>@ticker
-        // String::from("!ticker@arr"),
-        // String::from("btcusdt@bookTicker"), // <symbol>@bookTicker
-        // String::from("!bookTicker"),
-        // String::from("btcusd_210924@forceOrder"), // <symbol>@forceOrder
-        // String::from("!forceOrder@arr"),
-        // String::from("btcusd_210924@depth20@100ms"), // <symbol>@depth<levels> OR <symbol>@depth<levels>@500ms OR <symbol>@depth<levels>@100ms. 
-        // String::from("btcusd_210924@depth@100ms"), // <symbol>@depth OR <symbol>@depth@500ms OR <symbol>@depth@100ms
+        String::from("btcusdt@kline_1m"),  // <symbol>@kline_<interval>
+        String::from("btcusdt_perpetual@continuousKline_1m"), // <pair>_<contractType>@continuousKline_<interval> e.g. "btcusd_next_quarter@continuousKline_1m"
+        String::from("btcusdt@miniTicker"),                   // <symbol>@miniTicker
+        String::from("!miniTicker@arr"),
+        String::from("btcusdt@ticker"), // <symbol>@ticker
+        String::from("!ticker@arr"),
+        String::from("btcusdt@bookTicker"), // <symbol>@bookTicker
+        String::from("!bookTicker"),
+        // forceOrder can take a while before a message comes in, since
+        // it depends on when a position is liquidated
+        String::from("btcusdt@forceOrder"), // <symbol>@forceOrder
+        String::from("!forceOrder@arr"),
+        String::from("btcusdt@depth20@100ms"), // <symbol>@depth<levels> OR <symbol>@depth<levels>@500ms OR <symbol>@depth<levels>@100ms.
+        String::from("btcusdt@depth@100ms"), // <symbol>@depth OR <symbol>@depth@500ms OR <symbol>@depth@100ms
     ];
-    let stream_examples_COIN = vec![
-            String::from("btcusdt@aggTrade"),               // <symbol>@aggTrade
-            // String::from("btcusd@indexPrice@1s"),                     //<pair>@indexPrice OR <pair>@indexPrice@1s
-            // String::from("btcusdt@markPrice"),
-            String::from("btcusd@kline_1m"),
-            String::from("btcusd@continuousKline_1m"),
-            String::from("btcusd@indexPriceKline_1m"),
-            String::from("btcusd@markPriceKline_1m"),
-            String::from("btcusd@miniTicker"),
-            String::from("!miniTicker@arr"),
-            String::from("btcusd_210924@ticker"),
-            String::from("!ticker@arr"),
-            String::from("btcusd_210924@bookTicker"),
-            String::from("!bookTicker"),
-            String::from("btcusd_210924@forceOrder"),
-            String::from("!forceOrder@arr"),
-            String::from("btcusd_210924@depth20@100ms"),
-            String::from("btcusd_210924@depth@100ms")];
-    
 
-    let callback_fn = |event: WebsocketEvent| {
+    let _stream_examples_coin = vec![
+        // taken from https://binance-docs.github.io/apidocs/delivery/en/#websocket-market-streams
+        //ok
+        // String::from("btcusd_210924@aggTrade"), // <symbol>@aggTrade
+        //ok
+        // String::from("btcusd@indexPrice@1s"),                     //<pair>@indexPrice OR <pair>@indexPrice@1s
+
+        // onbekend
+        String::from("btcusd_210924@markPrice"), // <symbol>@markPrice OR <symbol>@markPrice@1s
+        String::from("btcusd@markPrice"), // <pair>@markPrice OR <pair>@markPrice@1s
+
+        // ok
+        String::from("btcusd_210924@kline_1m"), // <symbol>@kline_<interval>
+        String::from("btcusd_210924@continuousKline_1m"), // <pair>_<contractType>@continuousKline_<interval>
+        String::from("btcusd_210924@indexPriceKline_1m"), // <pair>@indexPriceKline_<interval>
+        String::from("btcusd_210924@markPriceKline_1m"),  // <symbol>@markPriceKline_<interval>
+        String::from("btcusd_210924@miniTicker"),         // <symbol>@miniTicker
+        String::from("!miniTicker@arr"),
+        String::from("btcusd_210924@ticker"), // <symbol>@ticker
+        String::from("!ticker@arr"),
+        String::from("btcusd_210924@bookTicker"), // <symbol>@bookTicker
+        String::from("!bookTicker"),
+        String::from("btcusd_210924@forceOrder"), // <symbol>@forceOrder
+        String::from("!forceOrder@arr"),
+        String::from("btcusd_210924@depth20@100ms"), // <symbol>@depth<levels> OR <symbol>@depth<levels>@500ms OR <symbol>@depth<levels>@100ms.
+        String::from("btcusd_210924@depth@100ms"), // <symbol>@depth OR <symbol>@depth@500ms OR <symbol>@depth@100ms
+    ];
+
+    let callback_fn = |event: FuturesWebsocketEvent| {
         println!("{:?}\n", event);
         keep_running.swap(false, Ordering::Relaxed);
         match event {
-            WebsocketEvent::Trade(trade) => {
+            FuturesWebsocketEvent::Trade(trade) => {
                 println!(
                     "Symbol: {}, price: {}, qty: {}",
                     trade.symbol, trade.price, trade.qty
                 );
                 keep_running.swap(false, Ordering::Relaxed);
             }
-            WebsocketEvent::DepthOrderBook(depth_order_book) => {
+            FuturesWebsocketEvent::DepthOrderBook(depth_order_book) => {
                 println!(
                     "Symbol: {}, Bids: {:?}, Ask: {:?}",
                     depth_order_book.symbol, depth_order_book.bids, depth_order_book.asks
                 );
                 keep_running.swap(false, Ordering::Relaxed);
             }
-            WebsocketEvent::OrderBook(order_book) => {
+            FuturesWebsocketEvent::OrderBook(order_book) => {
                 println!(
                     "last_update_id: {}, Bids: {:?}, Ask: {:?}",
                     order_book.last_update_id, order_book.bids, order_book.asks
@@ -93,8 +91,7 @@ fn market_websocket() {
 
         Ok(())
     };
-
-    for stream_example in stream_examples_USD {
+    for stream_example in stream_examples_usd {
         keep_running.swap(true, Ordering::Relaxed);
 
         let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(callback_fn);
@@ -104,4 +101,15 @@ fn market_websocket() {
         web_socket.event_loop(&keep_running).unwrap();
         web_socket.disconnect().unwrap();
     }
+
+    // for stream_example in stream_examples_coin {
+    //     keep_running.swap(true, Ordering::Relaxed);
+
+    //     let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(callback_fn);
+    //     web_socket
+    //         .connect(FuturesMarket::COINM, &stream_example)
+    //         .unwrap();
+    //     web_socket.event_loop(&keep_running).unwrap();
+    //     web_socket.disconnect().unwrap();
+    // }
 }

--- a/examples/binance_futures_websockets.rs
+++ b/examples/binance_futures_websockets.rs
@@ -1,7 +1,6 @@
-use binance::api::*;
 use binance::websockets::*;
-// use binance::userstream::*;
 use binance::futures::websockets::*;
+use tungstenite::stream;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 fn main() {
@@ -14,15 +13,59 @@ fn main() {
     // multiple_streams();
 }
 
-
 fn market_websocket() {
     let keep_running = AtomicBool::new(true);
+    let stream_examples_USD = vec![
+        // works
+        String::from("btcusdt@aggTrade"),               // <symbol>@aggTrade
+        
+        // does not work
+        // String::from("btcusdt@indexPrice@1s"),                     //<pair>@indexPrice OR <pair>@indexPrice@1s
+        
+        // works
+        String::from("btcusdt@markPrice"), // <symbol>@markPrice OR <symbol>@markPrice@1s
 
-    let agg_trade: String = String::from("btcusd_210924@bookTicker");
-    // let agg_trade: String = String::from("btcusd_200925@aggTrade");
+        // String::from("btcusd_210924@markPrice"), // <pair>@markPrice OR <pair>@markPrice@1s
 
-    let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(|event: WebsocketEvent| {
-        println!("{:?}", event);
+        // String::from("btcusdt@kline_1m"), // <symbol>@kline_<interval>
+
+        // String::from("btcusd_210924@continuousKline_1m"), // <pair>_<contractType>@continuousKline_<interval> e.g. "btcusd_next_quarter@continuousKline_1m"
+        // String::from("btcusd_210924@indexPriceKline_1m"), // <pair>@indexPriceKline_<interval> e.g. "btcusd@indexPriceKline_1m"
+        // String::from("btcusd_210924@markPriceKline_1m"), // <symbol>@markPriceKline_<interval> e.g. e.g. "btcusd_200626@markPriceKline_1m"
+        // String::from("btcusdt@miniTicker"), // <symbol>@miniTicker
+        // String::from("!miniTicker@arr"),
+        // String::from("btcusdt@ticker"), // <symbol>@ticker
+        // String::from("!ticker@arr"),
+        // String::from("btcusdt@bookTicker"), // <symbol>@bookTicker
+        // String::from("!bookTicker"),
+        // String::from("btcusd_210924@forceOrder"), // <symbol>@forceOrder
+        // String::from("!forceOrder@arr"),
+        // String::from("btcusd_210924@depth20@100ms"), // <symbol>@depth<levels> OR <symbol>@depth<levels>@500ms OR <symbol>@depth<levels>@100ms. 
+        // String::from("btcusd_210924@depth@100ms"), // <symbol>@depth OR <symbol>@depth@500ms OR <symbol>@depth@100ms
+    ];
+    let stream_examples_COIN = vec![
+            String::from("btcusdt@aggTrade"),               // <symbol>@aggTrade
+            // String::from("btcusd@indexPrice@1s"),                     //<pair>@indexPrice OR <pair>@indexPrice@1s
+            // String::from("btcusdt@markPrice"),
+            String::from("btcusd@kline_1m"),
+            String::from("btcusd@continuousKline_1m"),
+            String::from("btcusd@indexPriceKline_1m"),
+            String::from("btcusd@markPriceKline_1m"),
+            String::from("btcusd@miniTicker"),
+            String::from("!miniTicker@arr"),
+            String::from("btcusd_210924@ticker"),
+            String::from("!ticker@arr"),
+            String::from("btcusd_210924@bookTicker"),
+            String::from("!bookTicker"),
+            String::from("btcusd_210924@forceOrder"),
+            String::from("!forceOrder@arr"),
+            String::from("btcusd_210924@depth20@100ms"),
+            String::from("btcusd_210924@depth@100ms")];
+    
+
+    let callback_fn = |event: WebsocketEvent| {
+        println!("{:?}\n", event);
+        keep_running.swap(false, Ordering::Relaxed);
         match event {
             WebsocketEvent::Trade(trade) => {
                 println!(
@@ -49,14 +92,16 @@ fn market_websocket() {
         };
 
         Ok(())
-    });
+    };
 
-    web_socket.connect(FuturesMarket::COINM, &agg_trade).unwrap(); // check error
-    if let Err(e) = web_socket.event_loop(&keep_running) {
-        println!("Error: {}", e);
+    for stream_example in stream_examples_USD {
+        keep_running.swap(true, Ordering::Relaxed);
+
+        let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(callback_fn);
+        web_socket
+            .connect(FuturesMarket::USD, &stream_example)
+            .unwrap();
+        web_socket.event_loop(&keep_running).unwrap();
+        web_socket.disconnect().unwrap();
     }
-    web_socket.disconnect().unwrap();
-    println!("disconnected");
 }
-
-

--- a/examples/binance_futures_websockets.rs
+++ b/examples/binance_futures_websockets.rs
@@ -72,6 +72,7 @@ fn market_websocket() {
 
     // USD-M futures examples
     for stream_example in stream_examples_usd_m {
+        println!("Starting with USD_M {:?}", stream_example);
         keep_running.swap(true, Ordering::Relaxed);
 
         let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(callback_fn);
@@ -84,6 +85,7 @@ fn market_websocket() {
 
     // COIN-M futures examples
     for stream_example in stream_examples_coin_m {
+        println!("Starting with COIN_M {:?}", stream_example);
         keep_running.swap(true, Ordering::Relaxed);
 
         let mut web_socket: FuturesWebSockets<'_> = FuturesWebSockets::new(callback_fn);

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -2,3 +2,4 @@ pub mod general;
 pub mod market;
 pub mod model;
 pub mod account;
+pub mod websockets;

--- a/src/futures/websockets.rs
+++ b/src/futures/websockets.rs
@@ -75,6 +75,8 @@ enum FuturesEvents {
     AccountUpdateEvent(AccountUpdateEvent),
     OrderTradeEvent(OrderTradeEvent),
     AggrTradesEvent(AggrTradesEvent),
+    IndexPriceEvent(IndexPriceEvent),
+    MarkPriceEvent(MarkPriceEvent),
     TradeEvent(TradeEvent),
     KlineEvent(KlineEvent),
     OrderBook(OrderBook),
@@ -132,18 +134,25 @@ impl<'a> FuturesWebSockets<'a> {
 
     fn handle_msg(&mut self, msg: &str) -> Result<()> {
         let value: serde_json::Value = serde_json::from_str(msg)?;
+        println!("{:?}", value);
 
         if let Some(data) = value.get("data") {
             self.handle_msg(&data.to_string())?;
             return Ok(());
         }
 
-        if let Ok(events) = serde_json::from_value::<FuturesEvents>(value) {
+        let dummy = serde_json::from_value::<FuturesEvents>(value);
+        println!("{:?}", dummy);
+
+        if let Ok(events) = dummy{
+            println!("{:?}", events);
             let action = match events {
                 FuturesEvents::Vec(v) => WebsocketEvent::DayTickerAll(v),
                 FuturesEvents::BookTickerEvent(v) => WebsocketEvent::BookTicker(v),
                 FuturesEvents::AccountUpdateEvent(v) => WebsocketEvent::AccountUpdate(v),
                 FuturesEvents::OrderTradeEvent(v) => WebsocketEvent::OrderTrade(v),
+                FuturesEvents::IndexPriceEvent(v) => WebsocketEvent::IndexPrice(v),
+                FuturesEvents::MarkPriceEvent(v) => WebsocketEvent::MarkPrice(v),
                 FuturesEvents::AggrTradesEvent(v) => WebsocketEvent::AggrTrades(v),
                 FuturesEvents::TradeEvent(v) => WebsocketEvent::Trade(v),
                 FuturesEvents::DayTickerEvent(v) => WebsocketEvent::DayTicker(v),

--- a/src/futures/websockets.rs
+++ b/src/futures/websockets.rs
@@ -18,7 +18,7 @@ enum FuturesWebsocketAPI {
 }
 
 pub enum FuturesMarket {
-    USD,
+    USDM,
     COINM,
     Vanilla
 }
@@ -27,7 +27,7 @@ impl FuturesWebsocketAPI {
     fn params(self, market: FuturesMarket, subscription: &str) -> String {
         let baseurl = match market
         {
-            FuturesMarket::USD => "wss://fstream.binance.com",
+            FuturesMarket::USDM => "wss://fstream.binance.com",
             FuturesMarket::COINM => "wss://dstream.binance.com",
             FuturesMarket::Vanilla => "wss://vstream.binance.com",
         };
@@ -58,9 +58,11 @@ pub enum FuturesWebsocketEvent {
     MiniTickerAll(Vec<MiniTickerEvent>),
     IndexPrice(IndexPriceEvent),
     MarkPrice(MarkPriceEvent),
+    MarkPriceAll(Vec<MarkPriceEvent>),
     DayTickerAll(Vec<DayTickerEvent>),
     Kline(KlineEvent),
     ContinuousKline(ContinuousKlineEvent),
+    IndexKline(IndexKlineEvent),
     Liquidation(LiquidationEvent),
     DepthOrderBook(DepthOrderBookEvent),
     BookTicker(BookTickerEvent),
@@ -84,9 +86,11 @@ enum FuturesEvents {
     AggrTradesEvent(AggrTradesEvent),
     IndexPriceEvent(IndexPriceEvent),
     MarkPriceEvent(MarkPriceEvent),
+    VecMarkPriceEvent(Vec<MarkPriceEvent>),
     TradeEvent(TradeEvent),
     KlineEvent(KlineEvent),
     ContinuousKlineEvent(ContinuousKlineEvent),
+    IndexKlineEvent(IndexKlineEvent),
     LiquidationEvent(LiquidationEvent),
     OrderBook(OrderBook),
     DepthOrderBookEvent(DepthOrderBookEvent),
@@ -165,8 +169,10 @@ impl<'a> FuturesWebSockets<'a> {
                 FuturesEvents::OrderTradeEvent(v) => FuturesWebsocketEvent::OrderTrade(v),
                 FuturesEvents::IndexPriceEvent(v) => FuturesWebsocketEvent::IndexPrice(v),
                 FuturesEvents::MarkPriceEvent(v) => FuturesWebsocketEvent::MarkPrice(v),
+                FuturesEvents::VecMarkPriceEvent(v) => FuturesWebsocketEvent::MarkPriceAll(v),
                 FuturesEvents::TradeEvent(v) => FuturesWebsocketEvent::Trade(v),
                 FuturesEvents::ContinuousKlineEvent(v) => FuturesWebsocketEvent::ContinuousKline(v),
+                FuturesEvents::IndexKlineEvent(v) => FuturesWebsocketEvent::IndexKline(v),
                 FuturesEvents::LiquidationEvent(v) => FuturesWebsocketEvent::Liquidation(v),
                 FuturesEvents::KlineEvent(v) => FuturesWebsocketEvent::Kline(v),
                 FuturesEvents::OrderBook(v) => FuturesWebsocketEvent::OrderBook(v),

--- a/src/model.rs
+++ b/src/model.rs
@@ -554,6 +554,57 @@ pub struct TradeEvent {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct IndexPriceEvent {
+    #[serde(rename = "e")]
+    pub event_type: String,
+
+    #[serde(rename = "E")]
+    pub event_time: u64,
+
+    #[serde(rename = "i")]
+    pub pair: String,
+
+    #[serde(rename = "p")]
+    pub price: f64,
+
+}
+// https://binance-docs.github.io/apidocs/futures/en/#mark-price-stream
+// https://binance-docs.github.io/apidocs/delivery/en/#mark-price-stream
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkPriceEvent {
+    #[serde(rename = "E")]
+    pub event_time: u64,
+
+    #[serde(with = "string_or_float")]
+    #[serde(rename = "P")]
+    pub estimate_settle_price: f64,
+
+    #[serde(rename = "T")]
+    pub next_funding_time: u64,
+
+    #[serde(rename = "e")]
+    pub event_type: String,
+
+    #[serde(with = "string_or_float")]
+    #[serde(rename = "i")]
+    pub index_price: f64,
+
+    #[serde(with = "string_or_float")]
+    #[serde(rename = "p")]
+    pub mark_price: f64,
+
+    #[serde(with = "string_or_float")]
+    #[serde(rename = "r")]
+    pub funding_rate: f64,
+
+    #[serde(rename = "s")]
+    pub symbol: String,
+}
+
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct BookTickerEvent {
     #[serde(rename = "u")]
     pub update_id: u64,

--- a/src/model.rs
+++ b/src/model.rs
@@ -565,7 +565,7 @@ pub struct IndexPriceEvent {
     pub pair: String,
 
     #[serde(rename = "p")]
-    pub price: f64,
+    pub price: String,
 
 }
 // https://binance-docs.github.io/apidocs/futures/en/#mark-price-stream
@@ -576,9 +576,8 @@ pub struct MarkPriceEvent {
     #[serde(rename = "E")]
     pub event_time: u64,
 
-    #[serde(with = "string_or_float")]
     #[serde(rename = "P")]
-    pub estimate_settle_price: f64,
+    pub estimate_settle_price: String,
 
     #[serde(rename = "T")]
     pub next_funding_time: u64,
@@ -586,22 +585,73 @@ pub struct MarkPriceEvent {
     #[serde(rename = "e")]
     pub event_type: String,
 
-    #[serde(with = "string_or_float")]
     #[serde(rename = "i")]
-    pub index_price: f64,
+    pub index_price: String,
 
-    #[serde(with = "string_or_float")]
     #[serde(rename = "p")]
-    pub mark_price: f64,
+    pub mark_price: String,
 
-    #[serde(with = "string_or_float")]
     #[serde(rename = "r")]
-    pub funding_rate: f64,
+    pub funding_rate: String,
 
     #[serde(rename = "s")]
     pub symbol: String,
 }
 
+
+// Object({"E": Number(1626118018407), "e": String("forceOrder"), "o": Object({"S": String("SELL"), "T": Number(1626118018404), "X": String("FILLED"), "ap": String("33028.07"), "f": String("IOC"), "l": String("0.010"), "o": String("LIMIT"), "p": String("32896.00"), "q": String("0.010"), "s": String("BTCUSDT"), "z": String("0.010")})})
+// https://binance-docs.github.io/apidocs/futures/en/#liquidation-order-streams
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LiquidationEvent {
+    #[serde(rename = "e")]
+    pub event_type: String,
+
+    #[serde(rename = "E")]
+    pub event_time: u64,
+
+    #[serde(rename = "o")]
+    pub liquidation_order: LiquidationOrder,
+
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LiquidationOrder {
+    #[serde(rename = "s")]
+    pub symbol: String,
+
+    #[serde(rename = "S")]
+    pub side: String,
+
+    #[serde(rename = "o")]
+    pub order_type: String,
+
+    #[serde(rename = "f")]
+    pub time_in_force: String,
+
+    #[serde(rename = "q")]
+    pub original_quantity: String,
+
+    #[serde(rename = "p")]
+    pub price: String,
+
+    #[serde(rename = "ap")]
+    pub average_price: String,
+
+    #[serde(rename = "X")]
+    pub order_status: String,
+
+    #[serde(rename = "l")]
+    pub order_last_filled_quantity: String,
+
+    #[serde(rename = "z")]
+    pub order_filled_accumulated_quantity: String,
+
+    #[serde(rename = "T")]
+    pub order_trade_time: u64,
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -700,6 +750,38 @@ pub struct DayTickerEvent {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct MiniTickerEvent {
+    #[serde(rename = "e")]
+    pub event_type: String,
+
+    #[serde(rename = "E")]
+    pub event_time: u64,
+
+    #[serde(rename = "s")]
+    pub symbol: String,
+
+    #[serde(rename = "c")]
+    pub close: String,
+
+    #[serde(rename = "o")]
+    pub open: String,
+
+    #[serde(rename = "h")]
+    pub high: String,
+
+    #[serde(rename = "l")]
+    pub low: String,
+
+    #[serde(rename = "v")]
+    pub volume: String,
+
+    #[serde(rename = "q")]
+    pub quote_volume: String,
+}
+
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct KlineEvent {
     #[serde(rename = "e")]
     pub event_type: String,
@@ -713,6 +795,28 @@ pub struct KlineEvent {
     #[serde(rename = "k")]
     pub kline: Kline,
 }
+
+// https://binance-docs.github.io/apidocs/futures/en/#continuous-contract-kline-candlestick-streams
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ContinuousKlineEvent {
+    #[serde(rename = "e")]
+    pub event_type: String,
+
+    #[serde(rename = "E")]
+    pub event_time: u64,
+
+    #[serde(rename = "ps")]
+    pub pair: String,
+
+    #[serde(rename = "ct")]
+    pub contract_type: String,
+
+    #[serde(rename = "k")]
+    pub kline: ContinuousKline,
+}
+
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct KlineSummary {
@@ -747,7 +851,7 @@ pub struct Kline {
 
     #[serde(rename = "T")]
     pub end_time: i64,
-
+    
     #[serde(rename = "s")]
     pub symbol: String,
 
@@ -777,6 +881,58 @@ pub struct Kline {
 
     #[serde(rename = "n")]
     pub number_of_trades: i32,
+
+    #[serde(rename = "x")]
+    pub is_final_bar: bool,
+
+    #[serde(rename = "q")]
+    pub quote_volume: String,
+
+    #[serde(rename = "V")]
+    pub active_buy_volume: String,
+
+    #[serde(rename = "Q")]
+    pub active_volume_buy_quote: String,
+
+    #[serde(skip, rename = "B")]
+    pub ignore_me: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ContinuousKline {
+    #[serde(rename = "t")]
+    pub start_time: i64,
+
+    #[serde(rename = "T")]
+    pub end_time: i64,
+
+    #[serde(rename = "i")]
+    pub interval: String,
+
+    #[serde(rename = "f")]
+    pub first_trade_id: i64,
+
+    #[serde(rename = "L")]
+    pub last_trade_id: i64,
+
+    #[serde(rename = "o")]
+    pub open: String,
+
+    #[serde(rename = "c")]
+    pub close: String,
+
+    #[serde(rename = "h")]
+    pub high: String,
+
+    #[serde(rename = "l")]
+    pub low: String,
+
+    #[serde(rename = "v")]
+    pub volume: String,
+
+    #[serde(rename = "n")]
+    pub number_of_trades: i64,
 
     #[serde(rename = "x")]
     pub is_final_bar: bool,

--- a/src/model.rs
+++ b/src/model.rs
@@ -586,7 +586,7 @@ pub struct MarkPriceEvent {
     pub event_type: String,
 
     #[serde(rename = "i")]
-    pub index_price: String,
+    pub index_price: Option<String>,
 
     #[serde(rename = "p")]
     pub mark_price: String,
@@ -818,6 +818,24 @@ pub struct ContinuousKlineEvent {
 }
 
 
+// https://binance-docs.github.io/apidocs/delivery/en/#index-kline-candlestick-streams
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexKlineEvent {
+    #[serde(rename = "e")]
+    pub event_type: String,
+
+    #[serde(rename = "E")]
+    pub event_time: u64,
+
+    #[serde(rename = "ps")]
+    pub pair: String,
+
+    #[serde(rename = "k")]
+    pub kline: IndexKline,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct KlineSummary {
     pub open_time: i64,
@@ -948,6 +966,62 @@ pub struct ContinuousKline {
 
     #[serde(skip, rename = "B")]
     pub ignore_me: String,
+}
+
+// https://binance-docs.github.io/apidocs/delivery/en/#index-kline-candlestick-streams
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexKline {
+    #[serde(rename = "t")]
+    pub start_time: i64,
+
+    #[serde(rename = "T")]
+    pub end_time: i64,
+
+    #[serde(skip, rename = "s")]
+    pub ignore_me: String,
+
+    #[serde(rename = "i")]
+    pub interval: String,
+
+    #[serde(rename = "f")]
+    pub first_trade_id: i64,
+
+    #[serde(rename = "L")]
+    pub last_trade_id: i64,
+
+    #[serde(rename = "o")]
+    pub open: String,
+
+    #[serde(rename = "c")]
+    pub close: String,
+
+    #[serde(rename = "h")]
+    pub high: String,
+
+    #[serde(rename = "l")]
+    pub low: String,
+
+    #[serde(rename = "v")]
+    pub volume: String,
+
+    #[serde(rename = "n")]
+    pub number_of_trades: i64,
+
+    #[serde(rename = "x")]
+    pub is_final_bar: bool,
+
+    #[serde(skip, rename = "q")]
+    pub ignore_me2: String,
+
+    #[serde(skip, rename = "V")]
+    pub ignore_me3: String,
+
+    #[serde(skip, rename = "Q")]
+    pub ignore_me4: String,
+
+    #[serde(skip, rename = "B")]
+    pub ignore_me5: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -37,13 +37,9 @@ pub enum WebsocketEvent {
     AggrTrades(AggrTradesEvent),
     Trade(TradeEvent),
     OrderBook(OrderBook),
-    IndexPrice(IndexPriceEvent),
-    MarkPrice(MarkPriceEvent),
     DayTicker(DayTickerEvent),
-    MiniTickerAll(Vec<MiniTickerEvent>),
     DayTickerAll(Vec<DayTickerEvent>),
     Kline(KlineEvent),
-    ContinuousKline(ContinuousKlineEvent),
     DepthOrderBook(DepthOrderBookEvent),
     BookTicker(BookTickerEvent),
 }

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -37,6 +37,8 @@ pub enum WebsocketEvent {
     AggrTrades(AggrTradesEvent),
     Trade(TradeEvent),
     OrderBook(OrderBook),
+    IndexPrice(IndexPriceEvent),
+    MarkPrice(MarkPriceEvent),
     DayTicker(DayTickerEvent),
     DayTickerAll(Vec<DayTickerEvent>),
     Kline(KlineEvent),

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -40,8 +40,10 @@ pub enum WebsocketEvent {
     IndexPrice(IndexPriceEvent),
     MarkPrice(MarkPriceEvent),
     DayTicker(DayTickerEvent),
+    MiniTickerAll(Vec<MiniTickerEvent>),
     DayTickerAll(Vec<DayTickerEvent>),
     Kline(KlineEvent),
+    ContinuousKline(ContinuousKlineEvent),
     DepthOrderBook(DepthOrderBookEvent),
     BookTicker(BookTickerEvent),
 }


### PR DESCRIPTION
Add support for future websockets: implemented the USD-M and COIN-M endpoints; vanilla options are not implemented yet.

There is an example that shows their working, but it depends on the uptime of the binance servers, so I didn't make this into a real test. Real tests (with a mocked) server would be nice. Also documentation is not 100% complete.

