### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
i noticed a couple of the github actions are out of date. This dependabot config will ensure that dependencies and actions stay up to date.

Bumping dependencies can result in the MSRV of the crate increasing. I can add a check for that, to prevent that happening by accident.

this PR shouldn't be merged before #165 to prevent accidental bumping of the MSRV