### PR TITLE
prefer 'HashMap' to 'BTreeMap' when ordering isn't important

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -6,7 +6,7 @@ use crate::model::{
 };
 use crate::client::Client;
 use crate::errors::Result;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fmt::Display;
 use crate::api::API;
 use crate::api::Spot;
@@ -88,7 +88,7 @@ impl Display for TimeInForce {
 impl Account {
     // Account Information
     pub fn get_account(&self) -> Result<AccountInformation> {
-        let request = build_signed_request(BTreeMap::new(), self.recv_window)?;
+        let request = build_signed_request(HashMap::new(), self.recv_window)?;
         self.client
             .get_signed(API::Spot(Spot::Account), Some(request))
     }
@@ -117,8 +117,8 @@ impl Account {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -127,7 +127,7 @@ impl Account {
 
     // All current open orders
     pub fn get_all_open_orders(&self) -> Result<Vec<Order>> {
-        let parameters: BTreeMap<String, String> = BTreeMap::new();
+        let parameters: HashMap<&'static str, String> = HashMap::new();
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -139,8 +139,8 @@ impl Account {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
             .delete_signed(API::Spot(Spot::OpenOrders), Some(request))
@@ -151,9 +151,9 @@ impl Account {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("orderId".into(), order_id.to_string());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("orderId", order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -167,9 +167,9 @@ impl Account {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("orderId".into(), order_id.to_string());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("orderId", order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -668,9 +668,9 @@ impl Account {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("orderId".into(), order_id.to_string());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("orderId", order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -683,9 +683,9 @@ impl Account {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("origClientOrderId".into(), orig_client_order_id);
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("origClientOrderId", orig_client_order_id);
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -698,9 +698,9 @@ impl Account {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("orderId".into(), order_id.to_string());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("orderId", order_id.to_string());
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
             .delete_signed::<Empty>(API::Spot(Spot::OrderTest), Some(request))
@@ -712,33 +712,33 @@ impl Account {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
             .get_signed(API::Spot(Spot::MyTrades), Some(request))
     }
 
-    fn build_order(&self, order: OrderRequest) -> BTreeMap<String, String> {
-        let mut order_parameters: BTreeMap<String, String> = BTreeMap::new();
+    fn build_order(&self, order: OrderRequest) -> HashMap<&'static str, String> {
+        let mut order_parameters = HashMap::new();
 
-        order_parameters.insert("symbol".into(), order.symbol);
-        order_parameters.insert("side".into(), order.order_side.to_string());
-        order_parameters.insert("type".into(), order.order_type.to_string());
-        order_parameters.insert("quantity".into(), order.qty.to_string());
+        order_parameters.insert("symbol", order.symbol);
+        order_parameters.insert("side", order.order_side.to_string());
+        order_parameters.insert("type", order.order_type.to_string());
+        order_parameters.insert("quantity", order.qty.to_string());
 
         if let Some(stop_price) = order.stop_price {
-            order_parameters.insert("stopPrice".into(), stop_price.to_string());
+            order_parameters.insert("stopPrice", stop_price.to_string());
         }
 
         if order.price != 0.0 {
-            order_parameters.insert("price".into(), order.price.to_string());
-            order_parameters.insert("timeInForce".into(), order.time_in_force.to_string());
+            order_parameters.insert("price", order.price.to_string());
+            order_parameters.insert("timeInForce", order.time_in_force.to_string());
         }
 
         if let Some(client_order_id) = order.new_client_order_id {
-            order_parameters.insert("newClientOrderId".into(), client_order_id);
+            order_parameters.insert("newClientOrderId", client_order_id);
         }
 
         order_parameters
@@ -746,21 +746,21 @@ impl Account {
 
     fn build_quote_quantity_order(
         &self, order: OrderQuoteQuantityRequest,
-    ) -> BTreeMap<String, String> {
-        let mut order_parameters: BTreeMap<String, String> = BTreeMap::new();
+    ) -> HashMap<&'static str, String> {
+        let mut order_parameters = HashMap::new();
 
-        order_parameters.insert("symbol".into(), order.symbol);
-        order_parameters.insert("side".into(), order.order_side.to_string());
-        order_parameters.insert("type".into(), order.order_type.to_string());
-        order_parameters.insert("quoteOrderQty".into(), order.quote_order_qty.to_string());
+        order_parameters.insert("symbol", order.symbol);
+        order_parameters.insert("side", order.order_side.to_string());
+        order_parameters.insert("type", order.order_type.to_string());
+        order_parameters.insert("quoteOrderQty", order.quote_order_qty.to_string());
 
         if order.price != 0.0 {
-            order_parameters.insert("price".into(), order.price.to_string());
-            order_parameters.insert("timeInForce".into(), order.time_in_force.to_string());
+            order_parameters.insert("price", order.price.to_string());
+            order_parameters.insert("timeInForce", order.time_in_force.to_string());
         }
 
         if let Some(client_order_id) = order.new_client_order_id {
-            order_parameters.insert("newClientOrderId".into(), client_order_id);
+            order_parameters.insert("newClientOrderId", client_order_id);
         }
 
         order_parameters

--- a/src/futures/account.rs
+++ b/src/futures/account.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fmt::Display;
 
 use crate::util::build_signed_request;
@@ -239,9 +239,9 @@ impl FuturesAccount {
     where
         S: Into<String>,
     {
-        let mut parameters = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("orderId".into(), order_id.to_string());
+        let mut parameters = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("orderId", order_id.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -254,9 +254,9 @@ impl FuturesAccount {
     where
         S: Into<String>,
     {
-        let mut parameters = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("origClientOrderId".into(), orig_client_order_id);
+        let mut parameters = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("origClientOrderId", orig_client_order_id);
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -343,50 +343,44 @@ impl FuturesAccount {
             .post_signed(API::Futures(Futures::Order), request)
     }
 
-    fn build_order(&self, order: OrderRequest) -> BTreeMap<String, String> {
-        let mut parameters = BTreeMap::new();
-        parameters.insert("symbol".into(), order.symbol);
-        parameters.insert("side".into(), order.side.to_string());
-        parameters.insert("type".into(), order.order_type.to_string());
+    fn build_order(&self, order: OrderRequest) -> HashMap<&'static str, String> {
+        let mut parameters = HashMap::new();
+        parameters.insert("symbol", order.symbol);
+        parameters.insert("side", order.side.to_string());
+        parameters.insert("type", order.order_type.to_string());
 
         if let Some(position_side) = order.position_side {
-            parameters.insert("positionSide".into(), position_side.to_string());
+            parameters.insert("positionSide", position_side.to_string());
         }
         if let Some(time_in_force) = order.time_in_force {
-            parameters.insert("timeInForce".into(), time_in_force.to_string());
+            parameters.insert("timeInForce", time_in_force.to_string());
         }
         if let Some(qty) = order.qty {
-            parameters.insert("quantity".into(), qty.to_string());
+            parameters.insert("quantity", qty.to_string());
         }
         if let Some(reduce_only) = order.reduce_only {
-            parameters.insert("reduceOnly".into(), reduce_only.to_string().to_uppercase());
+            parameters.insert("reduceOnly", reduce_only.to_string().to_uppercase());
         }
         if let Some(price) = order.price {
-            parameters.insert("price".into(), price.to_string());
+            parameters.insert("price", price.to_string());
         }
         if let Some(stop_price) = order.stop_price {
-            parameters.insert("stopPrice".into(), stop_price.to_string());
+            parameters.insert("stopPrice", stop_price.to_string());
         }
         if let Some(close_position) = order.close_position {
-            parameters.insert(
-                "closePosition".into(),
-                close_position.to_string().to_uppercase(),
-            );
+            parameters.insert("closePosition", close_position.to_string().to_uppercase());
         }
         if let Some(activation_price) = order.activation_price {
-            parameters.insert("activationPrice".into(), activation_price.to_string());
+            parameters.insert("activationPrice", activation_price.to_string());
         }
         if let Some(callback_rate) = order.callback_rate {
-            parameters.insert("callbackRate".into(), callback_rate.to_string());
+            parameters.insert("callbackRate", callback_rate.to_string());
         }
         if let Some(working_type) = order.working_type {
-            parameters.insert("workingType".into(), working_type.to_string());
+            parameters.insert("workingType", working_type.to_string());
         }
         if let Some(price_protect) = order.price_protect {
-            parameters.insert(
-                "priceProtect".into(),
-                price_protect.to_string().to_uppercase(),
-            );
+            parameters.insert("priceProtect", price_protect.to_string().to_uppercase());
         }
 
         parameters
@@ -396,8 +390,8 @@ impl FuturesAccount {
     where
         S: Into<String>,
     {
-        let mut parameters = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters = HashMap::new();
+        parameters.insert("symbol", symbol.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -405,7 +399,7 @@ impl FuturesAccount {
     }
 
     pub fn account_information(&self) -> Result<AccountInformation> {
-        let parameters = BTreeMap::new();
+        let parameters = HashMap::new();
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -413,7 +407,7 @@ impl FuturesAccount {
     }
 
     pub fn account_balance(&self) -> Result<Vec<AccountBalance>> {
-        let parameters = BTreeMap::new();
+        let parameters = HashMap::new();
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -426,9 +420,9 @@ impl FuturesAccount {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("leverage".into(), leverage.to_string());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("leverage", leverage.to_string());
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -436,9 +430,9 @@ impl FuturesAccount {
     }
 
     pub fn change_position_mode(&self, dual_side_position: bool) -> Result<()> {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
         let dual_side = if dual_side_position { "true" } else { "false" };
-        parameters.insert("dualSidePosition".into(), dual_side.into());
+        parameters.insert("dualSidePosition", dual_side.into());
 
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -450,8 +444,8 @@ impl FuturesAccount {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
             .delete_signed::<Empty>(API::Futures(Futures::AllOpenOrders), Some(request))
@@ -462,8 +456,8 @@ impl FuturesAccount {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
             .get_signed(API::Futures(Futures::OpenOrders), Some(request))

--- a/src/futures/market.rs
+++ b/src/futures/market.rs
@@ -27,10 +27,10 @@ use crate::futures::model::{
 };
 use crate::client::Client;
 use crate::errors::Result;
-use std::collections::BTreeMap;
 use serde_json::Value;
 use crate::api::API;
 use crate::api::Futures;
+use std::collections::HashMap;
 use std::convert::TryInto;
 
 // TODO
@@ -50,9 +50,9 @@ impl FuturesMarket {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        let mut parameters = HashMap::new();
 
-        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
 
         self.client.get(API::Futures(Futures::Depth), Some(request))
@@ -64,9 +64,9 @@ impl FuturesMarket {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("limit".into(), depth.to_string());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("limit", depth.to_string());
         let request = build_request(parameters);
         self.client.get(API::Futures(Futures::Depth), Some(request))
     }
@@ -75,8 +75,8 @@ impl FuturesMarket {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
         self.client
             .get(API::Futures(Futures::Trades), Some(request))
@@ -91,16 +91,16 @@ impl FuturesMarket {
         S2: Into<Option<u64>>,
         S3: Into<Option<u16>>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
 
-        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("symbol", symbol.into());
 
         // Add three optional parameters
         if let Some(lt) = limit.into() {
-            parameters.insert("limit".into(), format!("{}", lt));
+            parameters.insert("limit", format!("{}", lt));
         }
         if let Some(fi) = from_id.into() {
-            parameters.insert("fromId".into(), format!("{}", fi));
+            parameters.insert("fromId", format!("{}", fi));
         }
 
         let request = build_signed_request(parameters, self.recv_window)?;
@@ -119,22 +119,22 @@ impl FuturesMarket {
         S4: Into<Option<u64>>,
         S5: Into<Option<u16>>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
 
-        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("symbol", symbol.into());
 
         // Add three optional parameters
         if let Some(lt) = limit.into() {
-            parameters.insert("limit".into(), format!("{}", lt));
+            parameters.insert("limit", format!("{}", lt));
         }
         if let Some(st) = start_time.into() {
-            parameters.insert("startTime".into(), format!("{}", st));
+            parameters.insert("startTime", format!("{}", st));
         }
         if let Some(et) = end_time.into() {
-            parameters.insert("endTime".into(), format!("{}", et));
+            parameters.insert("endTime", format!("{}", et));
         }
         if let Some(fi) = from_id.into() {
-            parameters.insert("fromId".into(), format!("{}", fi));
+            parameters.insert("fromId", format!("{}", fi));
         }
 
         let request = build_request(parameters);
@@ -155,20 +155,20 @@ impl FuturesMarket {
         S4: Into<Option<u64>>,
         S5: Into<Option<u64>>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
 
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("interval".into(), interval.into());
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("interval", interval.into());
 
         // Add three optional parameters
         if let Some(lt) = limit.into() {
-            parameters.insert("limit".into(), format!("{}", lt));
+            parameters.insert("limit", format!("{}", lt));
         }
         if let Some(st) = start_time.into() {
-            parameters.insert("startTime".into(), format!("{}", st));
+            parameters.insert("startTime", format!("{}", st));
         }
         if let Some(et) = end_time.into() {
-            parameters.insert("endTime".into(), format!("{}", et));
+            parameters.insert("endTime", format!("{}", et));
         }
 
         let request = build_request(parameters);
@@ -191,9 +191,9 @@ impl FuturesMarket {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
 
-        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
 
         self.client
@@ -210,9 +210,9 @@ impl FuturesMarket {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
 
-        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
 
         self.client
@@ -235,8 +235,8 @@ impl FuturesMarket {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
         self.client
             .get(API::Futures(Futures::BookTicker), Some(request))
@@ -254,8 +254,8 @@ impl FuturesMarket {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
         self.client
             .get(API::Futures(Futures::OpenInterest), Some(request))
@@ -271,18 +271,18 @@ impl FuturesMarket {
         S4: Into<Option<u64>>,
         S5: Into<Option<u64>>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("period".into(), period.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("period", period.into());
 
         if let Some(lt) = limit.into() {
-            parameters.insert("limit".into(), format!("{}", lt));
+            parameters.insert("limit", format!("{}", lt));
         }
         if let Some(st) = start_time.into() {
-            parameters.insert("startTime".into(), format!("{}", st));
+            parameters.insert("startTime", format!("{}", st));
         }
         if let Some(et) = end_time.into() {
-            parameters.insert("endTime".into(), format!("{}", et));
+            parameters.insert("endTime", format!("{}", et));
         }
 
         let request = build_request(parameters);

--- a/src/market.rs
+++ b/src/market.rs
@@ -5,7 +5,7 @@ use crate::model::{
 };
 use crate::client::Client;
 use crate::errors::Result;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use serde_json::Value;
 use crate::api::API;
 use crate::api::Spot;
@@ -24,8 +24,8 @@ impl Market {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
         self.client.get(API::Spot(Spot::Depth), Some(request))
     }
@@ -36,9 +36,9 @@ impl Market {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("limit".into(), depth.to_string());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("limit", depth.to_string());
         let request = build_request(parameters);
         self.client.get(API::Spot(Spot::Depth), Some(request))
     }
@@ -53,8 +53,8 @@ impl Market {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
         self.client.get(API::Spot(Spot::Price), Some(request))
     }
@@ -64,8 +64,8 @@ impl Market {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
         self.client.get(API::Spot(Spot::AvgPrice), Some(request))
     }
@@ -81,8 +81,8 @@ impl Market {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
         self.client.get(API::Spot(Spot::BookTicker), Some(request))
     }
@@ -92,8 +92,8 @@ impl Market {
     where
         S: Into<String>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("symbol".into(), symbol.into());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("symbol", symbol.into());
         let request = build_request(parameters);
         self.client.get(API::Spot(Spot::Ticker24hr), Some(request))
     }
@@ -117,22 +117,22 @@ impl Market {
         S4: Into<Option<u64>>,
         S5: Into<Option<u16>>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
 
-        parameters.insert("symbol".into(), symbol.into());
+        parameters.insert("symbol", symbol.into());
 
         // Add three optional parameters
         if let Some(lt) = limit.into() {
-            parameters.insert("limit".into(), format!("{}", lt));
+            parameters.insert("limit", format!("{}", lt));
         }
         if let Some(st) = start_time.into() {
-            parameters.insert("startTime".into(), format!("{}", st));
+            parameters.insert("startTime", format!("{}", st));
         }
         if let Some(et) = end_time.into() {
-            parameters.insert("endTime".into(), format!("{}", et));
+            parameters.insert("endTime", format!("{}", et));
         }
         if let Some(fi) = from_id.into() {
-            parameters.insert("fromId".into(), format!("{}", fi));
+            parameters.insert("fromId", format!("{}", fi));
         }
 
         let request = build_request(parameters);
@@ -152,20 +152,20 @@ impl Market {
         S4: Into<Option<u64>>,
         S5: Into<Option<u64>>,
     {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
 
-        parameters.insert("symbol".into(), symbol.into());
-        parameters.insert("interval".into(), interval.into());
+        parameters.insert("symbol", symbol.into());
+        parameters.insert("interval", interval.into());
 
         // Add three optional parameters
         if let Some(lt) = limit.into() {
-            parameters.insert("limit".into(), format!("{}", lt));
+            parameters.insert("limit", format!("{}", lt));
         }
         if let Some(st) = start_time.into() {
-            parameters.insert("startTime".into(), format!("{}", st));
+            parameters.insert("startTime", format!("{}", st));
         }
         if let Some(et) = end_time.into() {
-            parameters.insert("endTime".into(), format!("{}", et));
+            parameters.insert("endTime", format!("{}", et));
         }
 
         let request = build_request(parameters);

--- a/src/savings.rs
+++ b/src/savings.rs
@@ -2,7 +2,7 @@ use crate::util::build_signed_request;
 use crate::model::{AssetDetail, CoinInfo, DepositAddress};
 use crate::client::Client;
 use crate::errors::Result;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use crate::api::API;
 use crate::api::Sapi;
 
@@ -15,16 +15,16 @@ pub struct Savings {
 impl Savings {
     /// Get all coins available for deposit and withdrawal
     pub fn get_all_coins(&self) -> Result<Vec<CoinInfo>> {
-        let request = build_signed_request(BTreeMap::new(), self.recv_window)?;
+        let request = build_signed_request(HashMap::new(), self.recv_window)?;
         self.client
             .get_signed(API::Savings(Sapi::AllCoins), Some(request))
     }
 
     /// Fetch details of assets supported on Binance.
     pub fn asset_detail(&self, asset: Option<String>) -> Result<BTreeMap<String, AssetDetail>> {
-        let mut parameters = BTreeMap::new();
+        let mut parameters = HashMap::new();
         if let Some(asset) = asset {
-            parameters.insert("asset".into(), asset);
+            parameters.insert("asset", asset);
         }
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client
@@ -39,10 +39,10 @@ impl Savings {
     where
         S: Into<String>,
     {
-        let mut parameters = BTreeMap::new();
-        parameters.insert("coin".into(), coin.into());
+        let mut parameters = HashMap::new();
+        parameters.insert("coin", coin.into());
         if let Some(network) = network {
-            parameters.insert("network".into(), network);
+            parameters.insert("network", network);
         }
         let request = build_signed_request(parameters, self.recv_window)?;
         self.client

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,10 @@
 use crate::errors::Result;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 use error_chain::bail;
 use serde_json::Value;
 
-pub fn build_request(parameters: BTreeMap<String, String>) -> String {
+pub fn build_request(parameters: HashMap<&'static str, String>) -> String {
     let mut request = String::new();
     for (key, value) in parameters {
         let param = format!("{}={}&", key, value);
@@ -15,19 +15,19 @@ pub fn build_request(parameters: BTreeMap<String, String>) -> String {
 }
 
 pub fn build_signed_request(
-    parameters: BTreeMap<String, String>, recv_window: u64,
+    parameters: HashMap<&'static str, String>, recv_window: u64,
 ) -> Result<String> {
     build_signed_request_custom(parameters, recv_window, SystemTime::now())
 }
 
 pub fn build_signed_request_custom(
-    mut parameters: BTreeMap<String, String>, recv_window: u64, start: SystemTime,
+    mut parameters: HashMap<&'static str, String>, recv_window: u64, start: SystemTime,
 ) -> Result<String> {
     if recv_window > 0 {
-        parameters.insert("recvWindow".into(), recv_window.to_string());
+        parameters.insert("recvWindow", recv_window.to_string());
     }
     if let Ok(timestamp) = get_timestamp(start) {
-        parameters.insert("timestamp".into(), timestamp.to_string());
+        parameters.insert("timestamp", timestamp.to_string());
         return Ok(build_request(parameters));
     }
     bail!("Failed to get timestamp")

--- a/tests/util_tests.rs
+++ b/tests/util_tests.rs
@@ -3,21 +3,21 @@ use binance::util::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeMap;
+    use std::collections::HashMap;
     use std::time::{SystemTime, UNIX_EPOCH};
     use float_cmp::*;
 
     #[test]
     fn build_request_empty() {
-        let parameters: BTreeMap<String, String> = BTreeMap::new();
+        let parameters: HashMap<&'static str, String> = HashMap::new();
         let result = build_request(parameters);
         assert!(result.is_empty());
     }
 
     #[test]
     fn build_request_not_empty() {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("recvWindow".into(), "1234".to_string());
+        let mut parameters: HashMap<&'static str, String> = HashMap::new();
+        parameters.insert("recvWindow", "1234".to_string());
         let result = build_request(parameters);
         assert_eq!(result, format!("recvWindow={}", 1234));
     }
@@ -31,7 +31,7 @@ mod tests {
         let timestamp =
             since_epoch.as_secs() * 1000 + u64::from(since_epoch.subsec_nanos()) / 1_000_000;
 
-        let parameters: BTreeMap<String, String> = BTreeMap::new();
+        let parameters: HashMap<&'static str, String> = HashMap::new();
         let result =
             binance::util::build_signed_request_custom(parameters, recv_window, now).unwrap();
 


### PR DESCRIPTION
not sure why BTreeMap has been used instead of HashMap here, given that there's no need to preserve ordering (is there?).

I've also removed some allocations by using `&'static str` for the keys instead of `String`. Should provide some (very) modest performance gains.

shame the benchmarks aren't working... \*cough\* #164 \*cough\*