### PR TITLE
deglob imports in tests and examples

### DIFF
--- a/benches/websocket_benchmark.rs
+++ b/benches/websocket_benchmark.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use binance::websockets::*;
+use binance::websockets::{WebSockets, WebsocketEvent};
 
 use core::time::Duration;
 

--- a/examples/binance_endpoints.rs
+++ b/examples/binance_endpoints.rs
@@ -1,9 +1,9 @@
-use binance::api::*;
-use binance::savings::*;
-use binance::config::*;
-use binance::general::*;
-use binance::account::*;
-use binance::market::*;
+use binance::api::Binance;
+use binance::savings::Savings;
+use binance::config::Config;
+use binance::general::General;
+use binance::account::Account;
+use binance::market::Market;
 use binance::model::KlineSummary;
 use binance::errors::ErrorKind as BinanceLibErrorKind;
 

--- a/examples/binance_futures_endpoints.rs
+++ b/examples/binance_futures_endpoints.rs
@@ -1,7 +1,9 @@
-use binance::api::*;
-use binance::futures::general::*;
-use binance::futures::market::*;
-use binance::futures::model::*;
+use binance::api::Binance;
+use binance::futures::general::FuturesGeneral;
+use binance::futures::market::FuturesMarket;
+use binance::futures::model::{
+    AggTrades, BookTickers, KlineSummaries, LiquidationOrders, MarkPrices, Trades,
+};
 use binance::errors::ErrorKind as BinanceLibErrorKind;
 
 fn main() {

--- a/examples/binance_futures_userstream.rs
+++ b/examples/binance_futures_userstream.rs
@@ -1,5 +1,5 @@
-use binance::api::*;
-use binance::futures::userstream::*;
+use binance::api::Binance;
+use binance::futures::userstream::FuturesUserStream;
 
 fn main() {
     user_stream();

--- a/examples/binance_futures_websockets.rs
+++ b/examples/binance_futures_websockets.rs
@@ -1,4 +1,4 @@
-use binance::futures::websockets::*;
+use binance::futures::websockets::{FuturesMarket, FuturesWebSockets, FuturesWebsocketEvent};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 fn main() {

--- a/examples/binance_save_all_trades.rs
+++ b/examples/binance_save_all_trades.rs
@@ -1,10 +1,10 @@
 use std::error::Error;
 use std::fs::File;
 use csv::Writer;
-use std::sync::atomic::{AtomicBool};
+use std::sync::atomic::AtomicBool;
 
-use binance::websockets::*;
-use binance::model::{DayTickerEvent};
+use binance::websockets::{WebsocketEvent, WebSockets};
+use binance::model::DayTickerEvent;
 
 fn main() {
     save_all_trades_websocket();

--- a/examples/binance_websockets.rs
+++ b/examples/binance_websockets.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
-use binance::api::*;
-use binance::userstream::*;
-use binance::websockets::*;
+use binance::api::Binance;
+use binance::userstream::UserStream;
+use binance::websockets::{WebSockets, WebsocketEvent};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 fn main() {

--- a/tests/account_tests.rs
+++ b/tests/account_tests.rs
@@ -1,857 +1,848 @@
-use binance::api::*;
-use binance::config::*;
-use binance::account::*;
-use binance::model::*;
+use binance::api::Binance;
+use binance::config::Config;
+use binance::account::{Account, OrderSide, OrderType, TimeInForce};
+use binance::model::{Order, OrderCanceled, TradeHistory, Transaction};
+use mockito::{mock, Matcher};
+use float_cmp::approx_eq;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use mockito::{mock, Matcher};
-    use float_cmp::*;
+#[test]
+fn get_account() {
+    let mock_get_account = mock("GET", "/api/v3/account")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "recvWindow=1234&timestamp=\\d+&signature=.*".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/get_account.json")
+        .create();
 
-    #[test]
-    fn get_account() {
-        let mock_get_account = mock("GET", "/api/v3/account")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "recvWindow=1234&timestamp=\\d+&signature=.*".into(),
-            ))
-            .with_body_from_file("tests/mocks/account/get_account.json")
-            .create();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let account = account.get_account().unwrap();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let account = account.get_account().unwrap();
+    mock_get_account.assert();
 
-        mock_get_account.assert();
+    assert!(approx_eq!(f32, account.maker_commission, 15.0, ulps = 2));
+    assert!(approx_eq!(f32, account.taker_commission, 15.0, ulps = 2));
+    assert!(approx_eq!(f32, account.buyer_commission, 0.0, ulps = 2));
+    assert!(approx_eq!(f32, account.seller_commission, 0.0, ulps = 2));
+    assert!(account.can_trade);
+    assert!(account.can_withdraw);
+    assert!(account.can_deposit);
 
-        assert!(approx_eq!(f32, account.maker_commission, 15.0, ulps = 2));
-        assert!(approx_eq!(f32, account.taker_commission, 15.0, ulps = 2));
-        assert!(approx_eq!(f32, account.buyer_commission, 0.0, ulps = 2));
-        assert!(approx_eq!(f32, account.seller_commission, 0.0, ulps = 2));
-        assert!(account.can_trade);
-        assert!(account.can_withdraw);
-        assert!(account.can_deposit);
+    assert!(!account.balances.is_empty());
 
-        assert!(!account.balances.is_empty());
+    let first_balance = &account.balances[0];
+    assert_eq!(first_balance.asset, "BTC");
+    assert_eq!(first_balance.free, "4723846.89208129");
+    assert_eq!(first_balance.locked, "0.00000000");
 
-        let first_balance = &account.balances[0];
-        assert_eq!(first_balance.asset, "BTC");
-        assert_eq!(first_balance.free, "4723846.89208129");
-        assert_eq!(first_balance.locked, "0.00000000");
+    let second_balance = &account.balances[1];
+    assert_eq!(second_balance.asset, "LTC");
+    assert_eq!(second_balance.free, "4763368.68006011");
+    assert_eq!(second_balance.locked, "0.00000000");
+}
 
-        let second_balance = &account.balances[1];
-        assert_eq!(second_balance.asset, "LTC");
-        assert_eq!(second_balance.free, "4763368.68006011");
-        assert_eq!(second_balance.locked, "0.00000000");
-    }
+#[test]
+fn get_balance() {
+    let mock_get_account = mock("GET", "/api/v3/account")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "recvWindow=1234&timestamp=\\d+&signature=.*".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/get_account.json")
+        .create();
 
-    #[test]
-    fn get_balance() {
-        let mock_get_account = mock("GET", "/api/v3/account")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "recvWindow=1234&timestamp=\\d+&signature=.*".into(),
-            ))
-            .with_body_from_file("tests/mocks/account/get_account.json")
-            .create();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let balance = account.get_balance("BTC").unwrap();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let balance = account.get_balance("BTC").unwrap();
+    mock_get_account.assert();
 
-        mock_get_account.assert();
+    assert_eq!(balance.asset, "BTC");
+    assert_eq!(balance.free, "4723846.89208129");
+    assert_eq!(balance.locked, "0.00000000");
+}
 
-        assert_eq!(balance.asset, "BTC");
-        assert_eq!(balance.free, "4723846.89208129");
-        assert_eq!(balance.locked, "0.00000000");
-    }
+#[test]
+fn get_open_orders() {
+    let mock_open_orders = mock("GET", "/api/v3/openOrders")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "recvWindow=1234&symbol=LTCBTC&timestamp=\\d+".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/get_open_orders.json")
+        .create();
 
-    #[test]
-    fn get_open_orders() {
-        let mock_open_orders = mock("GET", "/api/v3/openOrders")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "recvWindow=1234&symbol=LTCBTC&timestamp=\\d+".into(),
-            ))
-            .with_body_from_file("tests/mocks/account/get_open_orders.json")
-            .create();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let open_orders = account.get_open_orders("LTCBTC").unwrap();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let open_orders = account.get_open_orders("LTCBTC").unwrap();
+    mock_open_orders.assert();
 
-        mock_open_orders.assert();
+    assert!(open_orders.len() == 1);
+    let open_order = &open_orders[0];
 
-        assert!(open_orders.len() == 1);
-        let open_order = &open_orders[0];
+    assert_eq!(open_order.symbol, "LTCBTC");
+    assert_eq!(open_order.order_id, 1);
+    assert_eq!(open_order.order_list_id, -1);
+    assert_eq!(open_order.client_order_id, "myOrder1");
+    assert!(approx_eq!(f64, open_order.price, 0.1, ulps = 2));
+    assert_eq!(open_order.orig_qty, "1.0");
+    assert_eq!(open_order.executed_qty, "0.0");
+    assert_eq!(open_order.cummulative_quote_qty, "0.0");
+    assert_eq!(open_order.status, "NEW");
+    assert_eq!(open_order.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(open_order.type_name, "LIMIT");
+    assert_eq!(open_order.side, "BUY");
+    assert!(approx_eq!(f64, open_order.stop_price, 0.0, ulps = 2));
+    assert_eq!(open_order.iceberg_qty, "0.0");
+    assert_eq!(open_order.time, 1499827319559);
+    assert_eq!(open_order.update_time, 1499827319559);
+    assert!(open_order.is_working);
+    assert_eq!(open_order.orig_quote_order_qty, "0.000000");
+}
 
-        assert_eq!(open_order.symbol, "LTCBTC");
-        assert_eq!(open_order.order_id, 1);
-        assert_eq!(open_order.order_list_id, -1);
-        assert_eq!(open_order.client_order_id, "myOrder1");
-        assert!(approx_eq!(f64, open_order.price, 0.1, ulps = 2));
-        assert_eq!(open_order.orig_qty, "1.0");
-        assert_eq!(open_order.executed_qty, "0.0");
-        assert_eq!(open_order.cummulative_quote_qty, "0.0");
-        assert_eq!(open_order.status, "NEW");
-        assert_eq!(open_order.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(open_order.type_name, "LIMIT");
-        assert_eq!(open_order.side, "BUY");
-        assert!(approx_eq!(f64, open_order.stop_price, 0.0, ulps = 2));
-        assert_eq!(open_order.iceberg_qty, "0.0");
-        assert_eq!(open_order.time, 1499827319559);
-        assert_eq!(open_order.update_time, 1499827319559);
-        assert!(open_order.is_working);
-        assert_eq!(open_order.orig_quote_order_qty, "0.000000");
-    }
+#[test]
+fn get_all_open_orders() {
+    let mock_open_orders = mock("GET", "/api/v3/openOrders")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex("recvWindow=1234&timestamp=\\d+".into()))
+        .with_body_from_file("tests/mocks/account/get_open_orders.json")
+        .create();
 
-    #[test]
-    fn get_all_open_orders() {
-        let mock_open_orders = mock("GET", "/api/v3/openOrders")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("recvWindow=1234&timestamp=\\d+".into()))
-            .with_body_from_file("tests/mocks/account/get_open_orders.json")
-            .create();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let open_orders = account.get_all_open_orders().unwrap();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let open_orders = account.get_all_open_orders().unwrap();
+    mock_open_orders.assert();
 
-        mock_open_orders.assert();
+    assert!(open_orders.len() == 1);
+    let open_order = &open_orders[0];
 
-        assert!(open_orders.len() == 1);
-        let open_order = &open_orders[0];
+    assert_eq!(open_order.symbol, "LTCBTC");
+    assert_eq!(open_order.order_id, 1);
+    assert_eq!(open_order.order_list_id, -1);
+    assert_eq!(open_order.client_order_id, "myOrder1");
+    assert!(approx_eq!(f64, open_order.price, 0.1, ulps = 2));
+    assert_eq!(open_order.orig_qty, "1.0");
+    assert_eq!(open_order.executed_qty, "0.0");
+    assert_eq!(open_order.cummulative_quote_qty, "0.0");
+    assert_eq!(open_order.status, "NEW");
+    assert_eq!(open_order.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(open_order.type_name, "LIMIT");
+    assert_eq!(open_order.side, "BUY");
+    assert!(approx_eq!(f64, open_order.stop_price, 0.0, ulps = 2));
+    assert_eq!(open_order.iceberg_qty, "0.0");
+    assert_eq!(open_order.time, 1499827319559);
+    assert_eq!(open_order.update_time, 1499827319559);
+    assert!(open_order.is_working);
+    assert_eq!(open_order.orig_quote_order_qty, "0.000000");
+}
 
-        assert_eq!(open_order.symbol, "LTCBTC");
-        assert_eq!(open_order.order_id, 1);
-        assert_eq!(open_order.order_list_id, -1);
-        assert_eq!(open_order.client_order_id, "myOrder1");
-        assert!(approx_eq!(f64, open_order.price, 0.1, ulps = 2));
-        assert_eq!(open_order.orig_qty, "1.0");
-        assert_eq!(open_order.executed_qty, "0.0");
-        assert_eq!(open_order.cummulative_quote_qty, "0.0");
-        assert_eq!(open_order.status, "NEW");
-        assert_eq!(open_order.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(open_order.type_name, "LIMIT");
-        assert_eq!(open_order.side, "BUY");
-        assert!(approx_eq!(f64, open_order.stop_price, 0.0, ulps = 2));
-        assert_eq!(open_order.iceberg_qty, "0.0");
-        assert_eq!(open_order.time, 1499827319559);
-        assert_eq!(open_order.update_time, 1499827319559);
-        assert!(open_order.is_working);
-        assert_eq!(open_order.orig_quote_order_qty, "0.000000");
-    }
+#[test]
+fn cancel_all_open_orders() {
+    let mock_cancel_all_open_orders = mock("DELETE", "/api/v3/openOrders")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/cancel_all_open_orders.json")
+        .create();
 
-    #[test]
-    fn cancel_all_open_orders() {
-        let mock_cancel_all_open_orders = mock("DELETE", "/api/v3/openOrders")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
-            ))
-            .with_body_from_file("tests/mocks/account/cancel_all_open_orders.json")
-            .create();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let cancel_all_open_orders = account.cancel_all_open_orders("BTCUSDT").unwrap();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let cancel_all_open_orders = account.cancel_all_open_orders("BTCUSDT").unwrap();
+    mock_cancel_all_open_orders.assert();
 
-        mock_cancel_all_open_orders.assert();
+    assert!(cancel_all_open_orders.len() == 3);
 
-        assert!(cancel_all_open_orders.len() == 3);
+    let first_order_cancelled: OrderCanceled = cancel_all_open_orders[0].clone();
+    assert_eq!(first_order_cancelled.symbol, "BTCUSDT");
+    assert_eq!(
+        first_order_cancelled.orig_client_order_id.unwrap(),
+        "E6APeyTJvkMvLMYMqu1KQ4"
+    );
+    assert_eq!(first_order_cancelled.order_id.unwrap(), 11);
+    assert_eq!(
+        first_order_cancelled.client_order_id.unwrap(),
+        "pXLV6Hz6mprAcVYpVMTGgx"
+    );
 
-        let first_order_cancelled: OrderCanceled = cancel_all_open_orders[0].clone();
-        assert_eq!(first_order_cancelled.symbol, "BTCUSDT");
-        assert_eq!(
-            first_order_cancelled.orig_client_order_id.unwrap(),
-            "E6APeyTJvkMvLMYMqu1KQ4"
-        );
-        assert_eq!(first_order_cancelled.order_id.unwrap(), 11);
-        assert_eq!(
-            first_order_cancelled.client_order_id.unwrap(),
-            "pXLV6Hz6mprAcVYpVMTGgx"
-        );
+    let second_order_cancelled: OrderCanceled = cancel_all_open_orders[1].clone();
+    assert_eq!(second_order_cancelled.symbol, "BTCUSDT");
+    assert_eq!(
+        second_order_cancelled.orig_client_order_id.unwrap(),
+        "A3EF2HCwxgZPFMrfwbgrhv"
+    );
+    assert_eq!(second_order_cancelled.order_id.unwrap(), 13);
+    assert_eq!(
+        second_order_cancelled.client_order_id.unwrap(),
+        "pXLV6Hz6mprAcVYpVMTGgx"
+    );
+}
 
-        let second_order_cancelled: OrderCanceled = cancel_all_open_orders[1].clone();
-        assert_eq!(second_order_cancelled.symbol, "BTCUSDT");
-        assert_eq!(
-            second_order_cancelled.orig_client_order_id.unwrap(),
-            "A3EF2HCwxgZPFMrfwbgrhv"
-        );
-        assert_eq!(second_order_cancelled.order_id.unwrap(), 13);
-        assert_eq!(
-            second_order_cancelled.client_order_id.unwrap(),
-            "pXLV6Hz6mprAcVYpVMTGgx"
-        );
-    }
+#[test]
+fn order_status() {
+    let mock_order_status = mock("GET", "/api/v3/order")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "orderId=1&recvWindow=1234&symbol=LTCBTC&timestamp=\\d+".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/order_status.json")
+        .create();
 
-    #[test]
-    fn order_status() {
-        let mock_order_status = mock("GET", "/api/v3/order")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "orderId=1&recvWindow=1234&symbol=LTCBTC&timestamp=\\d+".into(),
-            ))
-            .with_body_from_file("tests/mocks/account/order_status.json")
-            .create();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let order_status: Order = account.order_status("LTCBTC", 1).unwrap();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let order_status: Order = account.order_status("LTCBTC", 1).unwrap();
+    mock_order_status.assert();
 
-        mock_order_status.assert();
+    assert_eq!(order_status.symbol, "LTCBTC");
+    assert_eq!(order_status.order_id, 1);
+    assert_eq!(order_status.order_list_id, -1);
+    assert_eq!(order_status.client_order_id, "myOrder1");
+    assert!(approx_eq!(f64, order_status.price, 0.1, ulps = 2));
+    assert_eq!(order_status.orig_qty, "1.0");
+    assert_eq!(order_status.executed_qty, "0.0");
+    assert_eq!(order_status.cummulative_quote_qty, "0.0");
+    assert_eq!(order_status.status, "NEW");
+    assert_eq!(order_status.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(order_status.type_name, "LIMIT");
+    assert_eq!(order_status.side, "BUY");
+    assert!(approx_eq!(f64, order_status.stop_price, 0.0, ulps = 2));
+    assert_eq!(order_status.iceberg_qty, "0.0");
+    assert_eq!(order_status.time, 1499827319559);
+    assert_eq!(order_status.update_time, 1499827319559);
+    assert!(order_status.is_working);
+    assert_eq!(order_status.orig_quote_order_qty, "0.000000");
+}
 
-        assert_eq!(order_status.symbol, "LTCBTC");
-        assert_eq!(order_status.order_id, 1);
-        assert_eq!(order_status.order_list_id, -1);
-        assert_eq!(order_status.client_order_id, "myOrder1");
-        assert!(approx_eq!(f64, order_status.price, 0.1, ulps = 2));
-        assert_eq!(order_status.orig_qty, "1.0");
-        assert_eq!(order_status.executed_qty, "0.0");
-        assert_eq!(order_status.cummulative_quote_qty, "0.0");
-        assert_eq!(order_status.status, "NEW");
-        assert_eq!(order_status.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(order_status.type_name, "LIMIT");
-        assert_eq!(order_status.side, "BUY");
-        assert!(approx_eq!(f64, order_status.stop_price, 0.0, ulps = 2));
-        assert_eq!(order_status.iceberg_qty, "0.0");
-        assert_eq!(order_status.time, 1499827319559);
-        assert_eq!(order_status.update_time, 1499827319559);
-        assert!(order_status.is_working);
-        assert_eq!(order_status.orig_quote_order_qty, "0.000000");
-    }
+#[test]
+fn test_order_status() {
+    let mock_test_order_status = mock("GET", "/api/v3/order/test")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "orderId=1&recvWindow=1234&symbol=LTCBTC&timestamp=\\d+".into(),
+        ))
+        .with_body("{}")
+        .create();
 
-    #[test]
-    fn test_order_status() {
-        let mock_test_order_status = mock("GET", "/api/v3/order/test")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "orderId=1&recvWindow=1234&symbol=LTCBTC&timestamp=\\d+".into(),
-            ))
-            .with_body("{}")
-            .create();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account.test_order_status("LTCBTC", 1).unwrap();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account.test_order_status("LTCBTC", 1).unwrap();
+    mock_test_order_status.assert();
+}
 
-        mock_test_order_status.assert();
-    }
-
-    #[test]
-    fn limit_buy() {
-        let mock_limit_buy = mock("POST", "/api/v3/order")
+#[test]
+fn limit_buy() {
+    let mock_limit_buy = mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=LIMIT".into()))
             .with_body_from_file("tests/mocks/account/limit_buy.json")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let transaction: Transaction = account.limit_buy("LTCBTC", 1, 0.1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let transaction: Transaction = account.limit_buy("LTCBTC", 1, 0.1).unwrap();
 
-        mock_limit_buy.assert();
+    mock_limit_buy.assert();
 
-        assert_eq!(transaction.symbol, "LTCBTC");
-        assert_eq!(transaction.order_id, 1);
-        assert_eq!(transaction.order_list_id.unwrap(), -1);
-        assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
-        assert_eq!(transaction.transact_time, 1507725176595);
-        assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
-        assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(
-            f64,
-            transaction.cummulative_quote_qty,
-            0.0,
-            ulps = 2
-        ));
-        assert_eq!(transaction.status, "NEW");
-        assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(transaction.type_name, "LIMIT");
-        assert_eq!(transaction.side, "BUY");
-    }
+    assert_eq!(transaction.symbol, "LTCBTC");
+    assert_eq!(transaction.order_id, 1);
+    assert_eq!(transaction.order_list_id.unwrap(), -1);
+    assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
+    assert_eq!(transaction.transact_time, 1507725176595);
+    assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
+    assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(
+        f64,
+        transaction.cummulative_quote_qty,
+        0.0,
+        ulps = 2
+    ));
+    assert_eq!(transaction.status, "NEW");
+    assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(transaction.type_name, "LIMIT");
+    assert_eq!(transaction.side, "BUY");
+}
 
-    #[test]
-    fn test_limit_buy() {
-        let mock_test_limit_buy = mock("POST", "/api/v3/order/test")
+#[test]
+fn test_limit_buy() {
+    let mock_test_limit_buy = mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=LIMIT".into()))
             .with_body("{}")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account.test_limit_buy("LTCBTC", 1, 0.1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account.test_limit_buy("LTCBTC", 1, 0.1).unwrap();
 
-        mock_test_limit_buy.assert();
-    }
+    mock_test_limit_buy.assert();
+}
 
-    #[test]
-    fn limit_sell() {
-        let mock_limit_sell = mock("POST", "/api/v3/order")
+#[test]
+fn limit_sell() {
+    let mock_limit_sell = mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=LIMIT".into()))
             .with_body_from_file("tests/mocks/account/limit_sell.json")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let transaction: Transaction = account.limit_sell("LTCBTC", 1, 0.1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let transaction: Transaction = account.limit_sell("LTCBTC", 1, 0.1).unwrap();
 
-        mock_limit_sell.assert();
+    mock_limit_sell.assert();
 
-        assert_eq!(transaction.symbol, "LTCBTC");
-        assert_eq!(transaction.order_id, 1);
-        assert_eq!(transaction.order_list_id.unwrap(), -1);
-        assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
-        assert_eq!(transaction.transact_time, 1507725176595);
-        assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
-        assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(
-            f64,
-            transaction.cummulative_quote_qty,
-            0.0,
-            ulps = 2
-        ));
-        assert_eq!(transaction.status, "NEW");
-        assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(transaction.type_name, "LIMIT");
-        assert_eq!(transaction.side, "SELL");
-    }
+    assert_eq!(transaction.symbol, "LTCBTC");
+    assert_eq!(transaction.order_id, 1);
+    assert_eq!(transaction.order_list_id.unwrap(), -1);
+    assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
+    assert_eq!(transaction.transact_time, 1507725176595);
+    assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
+    assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(
+        f64,
+        transaction.cummulative_quote_qty,
+        0.0,
+        ulps = 2
+    ));
+    assert_eq!(transaction.status, "NEW");
+    assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(transaction.type_name, "LIMIT");
+    assert_eq!(transaction.side, "SELL");
+}
 
-    #[test]
-    fn test_limit_sell() {
-        let mock_test_limit_sell = mock("POST", "/api/v3/order/test")
+#[test]
+fn test_limit_sell() {
+    let mock_test_limit_sell = mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=LIMIT".into()))
             .with_body("{}")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account.test_limit_sell("LTCBTC", 1, 0.1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account.test_limit_sell("LTCBTC", 1, 0.1).unwrap();
 
-        mock_test_limit_sell.assert();
-    }
+    mock_test_limit_sell.assert();
+}
 
-    #[test]
-    fn market_buy() {
-        let mock_market_buy = mock("POST", "/api/v3/order")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timestamp=\\d+&type=MARKET"
-                    .into(),
-            ))
-            .with_body_from_file("tests/mocks/account/market_buy.json")
-            .create();
+#[test]
+fn market_buy() {
+    let mock_market_buy = mock("POST", "/api/v3/order")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timestamp=\\d+&type=MARKET".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/market_buy.json")
+        .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let transaction: Transaction = account.market_buy("LTCBTC", 1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let transaction: Transaction = account.market_buy("LTCBTC", 1).unwrap();
 
-        mock_market_buy.assert();
+    mock_market_buy.assert();
 
-        assert_eq!(transaction.symbol, "LTCBTC");
-        assert_eq!(transaction.order_id, 1);
-        assert_eq!(transaction.order_list_id.unwrap(), -1);
-        assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
-        assert_eq!(transaction.transact_time, 1507725176595);
-        assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
-        assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(
-            f64,
-            transaction.cummulative_quote_qty,
-            0.0,
-            ulps = 2
-        ));
-        assert_eq!(transaction.status, "NEW");
-        assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(transaction.type_name, "MARKET");
-        assert_eq!(transaction.side, "BUY");
-    }
+    assert_eq!(transaction.symbol, "LTCBTC");
+    assert_eq!(transaction.order_id, 1);
+    assert_eq!(transaction.order_list_id.unwrap(), -1);
+    assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
+    assert_eq!(transaction.transact_time, 1507725176595);
+    assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
+    assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(
+        f64,
+        transaction.cummulative_quote_qty,
+        0.0,
+        ulps = 2
+    ));
+    assert_eq!(transaction.status, "NEW");
+    assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(transaction.type_name, "MARKET");
+    assert_eq!(transaction.side, "BUY");
+}
 
-    #[test]
-    fn test_market_buy() {
-        let mock_test_market_buy = mock("POST", "/api/v3/order/test")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timestamp=\\d+&type=MARKET"
-                    .into(),
-            ))
-            .with_body("{}")
-            .create();
+#[test]
+fn test_market_buy() {
+    let mock_test_market_buy = mock("POST", "/api/v3/order/test")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timestamp=\\d+&type=MARKET".into(),
+        ))
+        .with_body("{}")
+        .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account.test_market_buy("LTCBTC", 1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account.test_market_buy("LTCBTC", 1).unwrap();
 
-        mock_test_market_buy.assert();
-    }
+    mock_test_market_buy.assert();
+}
 
-    #[test]
-    fn market_buy_using_quote_quantity() {
-        let mock_market_buy_using_quote_quantity = mock("POST", "/api/v3/order")
+#[test]
+fn market_buy_using_quote_quantity() {
+    let mock_market_buy_using_quote_quantity = mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("quoteOrderQty=0.002&recvWindow=1234&side=BUY&symbol=BNBBTC&timestamp=\\d+&type=MARKET&signature=.*".into()))
             .with_body_from_file("tests/mocks/account/market_buy_using_quote_quantity.json")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        match account.market_buy_using_quote_quantity("BNBBTC", 0.002) {
-            Ok(answer) => {
-                assert!(answer.order_id == 1);
-            }
-            Err(e) => panic!("Error: {}", e),
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    match account.market_buy_using_quote_quantity("BNBBTC", 0.002) {
+        Ok(answer) => {
+            assert!(answer.order_id == 1);
         }
-
-        mock_market_buy_using_quote_quantity.assert();
+        Err(e) => panic!("Error: {}", e),
     }
 
-    #[test]
-    fn test_market_buy_using_quote_quantity() {
-        let mock_test_market_buy_using_quote_quantity = mock("POST", "/api/v3/order/test")
+    mock_market_buy_using_quote_quantity.assert();
+}
+
+#[test]
+fn test_market_buy_using_quote_quantity() {
+    let mock_test_market_buy_using_quote_quantity = mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("quoteOrderQty=0.002&recvWindow=1234&side=BUY&symbol=BNBBTC&timestamp=\\d+&type=MARKET&signature=.*".into()))
             .with_body("{}")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account
-            .test_market_buy_using_quote_quantity("BNBBTC", 0.002)
-            .unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account
+        .test_market_buy_using_quote_quantity("BNBBTC", 0.002)
+        .unwrap();
 
-        mock_test_market_buy_using_quote_quantity.assert();
-    }
+    mock_test_market_buy_using_quote_quantity.assert();
+}
 
-    #[test]
-    fn market_sell() {
-        let mock_market_sell = mock("POST", "/api/v3/order")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timestamp=\\d+&type=MARKET"
-                    .into(),
-            ))
-            .with_body_from_file("tests/mocks/account/market_sell.json")
-            .create();
+#[test]
+fn market_sell() {
+    let mock_market_sell = mock("POST", "/api/v3/order")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timestamp=\\d+&type=MARKET".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/market_sell.json")
+        .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let transaction: Transaction = account.market_sell("LTCBTC", 1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let transaction: Transaction = account.market_sell("LTCBTC", 1).unwrap();
 
-        mock_market_sell.assert();
+    mock_market_sell.assert();
 
-        assert_eq!(transaction.symbol, "LTCBTC");
-        assert_eq!(transaction.order_id, 1);
-        assert_eq!(transaction.order_list_id.unwrap(), -1);
-        assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
-        assert_eq!(transaction.transact_time, 1507725176595);
-        assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
-        assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(
-            f64,
-            transaction.cummulative_quote_qty,
-            0.0,
-            ulps = 2
-        ));
-        assert_eq!(transaction.status, "NEW");
-        assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(transaction.type_name, "MARKET");
-        assert_eq!(transaction.side, "SELL");
-    }
+    assert_eq!(transaction.symbol, "LTCBTC");
+    assert_eq!(transaction.order_id, 1);
+    assert_eq!(transaction.order_list_id.unwrap(), -1);
+    assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
+    assert_eq!(transaction.transact_time, 1507725176595);
+    assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
+    assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(
+        f64,
+        transaction.cummulative_quote_qty,
+        0.0,
+        ulps = 2
+    ));
+    assert_eq!(transaction.status, "NEW");
+    assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(transaction.type_name, "MARKET");
+    assert_eq!(transaction.side, "SELL");
+}
 
-    #[test]
-    fn test_market_sell() {
-        let mock_test_market_sell = mock("POST", "/api/v3/order/test")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timestamp=\\d+&type=MARKET"
-                    .into(),
-            ))
-            .with_body("{}")
-            .create();
+#[test]
+fn test_market_sell() {
+    let mock_test_market_sell = mock("POST", "/api/v3/order/test")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timestamp=\\d+&type=MARKET".into(),
+        ))
+        .with_body("{}")
+        .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account.test_market_sell("LTCBTC", 1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account.test_market_sell("LTCBTC", 1).unwrap();
 
-        mock_test_market_sell.assert();
-    }
+    mock_test_market_sell.assert();
+}
 
-    #[test]
-    fn market_sell_using_quote_quantity() {
-        let mock_market_sell_using_quote_quantity = mock("POST", "/api/v3/order")
+#[test]
+fn market_sell_using_quote_quantity() {
+    let mock_market_sell_using_quote_quantity = mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("quoteOrderQty=0.002&recvWindow=1234&side=SELL&symbol=BNBBTC&timestamp=\\d+&type=MARKET&signature=.*".into()))
             .with_body_from_file("tests/mocks/account/market_sell_using_quote_quantity.json")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        match account.market_sell_using_quote_quantity("BNBBTC", 0.002) {
-            Ok(answer) => {
-                assert!(answer.order_id == 1);
-            }
-            Err(e) => panic!("Error: {}", e),
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    match account.market_sell_using_quote_quantity("BNBBTC", 0.002) {
+        Ok(answer) => {
+            assert!(answer.order_id == 1);
         }
-
-        mock_market_sell_using_quote_quantity.assert();
+        Err(e) => panic!("Error: {}", e),
     }
 
-    #[test]
-    fn test_market_sell_using_quote_quantity() {
-        let mock_test_market_sell_using_quote_quantity = mock("POST", "/api/v3/order/test")
+    mock_market_sell_using_quote_quantity.assert();
+}
+
+#[test]
+fn test_market_sell_using_quote_quantity() {
+    let mock_test_market_sell_using_quote_quantity = mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("quoteOrderQty=0.002&recvWindow=1234&side=SELL&symbol=BNBBTC&timestamp=\\d+&type=MARKET&signature=.*".into()))
             .with_body("{}")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account
-            .test_market_sell_using_quote_quantity("BNBBTC", 0.002)
-            .unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account
+        .test_market_sell_using_quote_quantity("BNBBTC", 0.002)
+        .unwrap();
 
-        mock_test_market_sell_using_quote_quantity.assert();
-    }
+    mock_test_market_sell_using_quote_quantity.assert();
+}
 
-    #[test]
-    fn stop_limit_buy_order() {
-        let mock_stop_limit_buy_order = mock("POST", "/api/v3/order")
+#[test]
+fn stop_limit_buy_order() {
+    let mock_stop_limit_buy_order = mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&stopPrice=0.09&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=STOP_LOSS_LIMIT".into()))
             .with_body_from_file("tests/mocks/account/stop_limit_buy.json")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let transaction: Transaction = account
-            .stop_limit_buy_order("LTCBTC", 1, 0.1, 0.09, TimeInForce::GTC)
-            .unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let transaction: Transaction = account
+        .stop_limit_buy_order("LTCBTC", 1, 0.1, 0.09, TimeInForce::GTC)
+        .unwrap();
 
-        mock_stop_limit_buy_order.assert();
+    mock_stop_limit_buy_order.assert();
 
-        assert_eq!(transaction.symbol, "LTCBTC");
-        assert_eq!(transaction.order_id, 1);
-        assert_eq!(transaction.order_list_id.unwrap(), -1);
-        assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
-        assert_eq!(transaction.transact_time, 1507725176595);
-        assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
-        assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(
-            f64,
-            transaction.cummulative_quote_qty,
-            0.0,
-            ulps = 2
-        ));
-        assert!(approx_eq!(f64, transaction.stop_price, 0.09, ulps = 2));
-        assert_eq!(transaction.status, "NEW");
-        assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(transaction.type_name, "STOP_LOSS_LIMIT");
-        assert_eq!(transaction.side, "BUY");
-    }
+    assert_eq!(transaction.symbol, "LTCBTC");
+    assert_eq!(transaction.order_id, 1);
+    assert_eq!(transaction.order_list_id.unwrap(), -1);
+    assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
+    assert_eq!(transaction.transact_time, 1507725176595);
+    assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
+    assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(
+        f64,
+        transaction.cummulative_quote_qty,
+        0.0,
+        ulps = 2
+    ));
+    assert!(approx_eq!(f64, transaction.stop_price, 0.09, ulps = 2));
+    assert_eq!(transaction.status, "NEW");
+    assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(transaction.type_name, "STOP_LOSS_LIMIT");
+    assert_eq!(transaction.side, "BUY");
+}
 
-    #[test]
-    fn test_stop_limit_buy_order() {
-        let mock_test_stop_limit_buy_order = mock("POST", "/api/v3/order/test")
+#[test]
+fn test_stop_limit_buy_order() {
+    let mock_test_stop_limit_buy_order = mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&stopPrice=0.09&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=STOP_LOSS_LIMIT".into()))
             .with_body("{}")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account
-            .test_stop_limit_buy_order("LTCBTC", 1, 0.1, 0.09, TimeInForce::GTC)
-            .unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account
+        .test_stop_limit_buy_order("LTCBTC", 1, 0.1, 0.09, TimeInForce::GTC)
+        .unwrap();
 
-        mock_test_stop_limit_buy_order.assert();
-    }
+    mock_test_stop_limit_buy_order.assert();
+}
 
-    #[test]
-    fn stop_limit_sell_order() {
-        let mock_stop_limit_sell_order = mock("POST", "/api/v3/order")
+#[test]
+fn stop_limit_sell_order() {
+    let mock_stop_limit_sell_order = mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=SELL&stopPrice=0.09&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=STOP_LOSS_LIMIT".into()))
             .with_body_from_file("tests/mocks/account/stop_limit_sell.json")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let transaction: Transaction = account
-            .stop_limit_sell_order("LTCBTC", 1, 0.1, 0.09, TimeInForce::GTC)
-            .unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let transaction: Transaction = account
+        .stop_limit_sell_order("LTCBTC", 1, 0.1, 0.09, TimeInForce::GTC)
+        .unwrap();
 
-        mock_stop_limit_sell_order.assert();
+    mock_stop_limit_sell_order.assert();
 
-        assert_eq!(transaction.symbol, "LTCBTC");
-        assert_eq!(transaction.order_id, 1);
-        assert_eq!(transaction.order_list_id.unwrap(), -1);
-        assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
-        assert_eq!(transaction.transact_time, 1507725176595);
-        assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
-        assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(
-            f64,
-            transaction.cummulative_quote_qty,
-            0.0,
-            ulps = 2
-        ));
-        assert!(approx_eq!(f64, transaction.stop_price, 0.09, ulps = 2));
-        assert_eq!(transaction.status, "NEW");
-        assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(transaction.type_name, "STOP_LOSS_LIMIT");
-        assert_eq!(transaction.side, "SELL");
-    }
+    assert_eq!(transaction.symbol, "LTCBTC");
+    assert_eq!(transaction.order_id, 1);
+    assert_eq!(transaction.order_list_id.unwrap(), -1);
+    assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
+    assert_eq!(transaction.transact_time, 1507725176595);
+    assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
+    assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(
+        f64,
+        transaction.cummulative_quote_qty,
+        0.0,
+        ulps = 2
+    ));
+    assert!(approx_eq!(f64, transaction.stop_price, 0.09, ulps = 2));
+    assert_eq!(transaction.status, "NEW");
+    assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(transaction.type_name, "STOP_LOSS_LIMIT");
+    assert_eq!(transaction.side, "SELL");
+}
 
-    #[test]
-    fn test_stop_limit_sell_order() {
-        let mock_test_stop_limit_sell_order = mock("POST", "/api/v3/order/test")
+#[test]
+fn test_stop_limit_sell_order() {
+    let mock_test_stop_limit_sell_order = mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=SELL&stopPrice=0.09&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=STOP_LOSS_LIMIT".into()))
             .with_body("{}")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account
-            .test_stop_limit_sell_order("LTCBTC", 1, 0.1, 0.09, TimeInForce::GTC)
-            .unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account
+        .test_stop_limit_sell_order("LTCBTC", 1, 0.1, 0.09, TimeInForce::GTC)
+        .unwrap();
 
-        mock_test_stop_limit_sell_order.assert();
-    }
+    mock_test_stop_limit_sell_order.assert();
+}
 
-    #[test]
-    fn custom_order() {
-        let mock_custom_order = mock("POST", "/api/v3/order")
+#[test]
+fn custom_order() {
+    let mock_custom_order = mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("newClientOrderId=6gCrw2kRUAF9CvJDGP16IP&price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=MARKET".into()))
             .with_body_from_file("tests/mocks/account/stop_limit_sell.json")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let transaction: Transaction = account
-            .custom_order(
-                "LTCBTC",
-                1,
-                0.1,
-                None,
-                OrderSide::Buy,
-                OrderType::Market,
-                TimeInForce::GTC,
-                Some("6gCrw2kRUAF9CvJDGP16IP".into()),
-            )
-            .unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let transaction: Transaction = account
+        .custom_order(
+            "LTCBTC",
+            1,
+            0.1,
+            None,
+            OrderSide::Buy,
+            OrderType::Market,
+            TimeInForce::GTC,
+            Some("6gCrw2kRUAF9CvJDGP16IP".into()),
+        )
+        .unwrap();
 
-        mock_custom_order.assert();
+    mock_custom_order.assert();
 
-        assert_eq!(transaction.symbol, "LTCBTC");
-        assert_eq!(transaction.order_id, 1);
-        assert_eq!(transaction.order_list_id.unwrap(), -1);
-        assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
-        assert_eq!(transaction.transact_time, 1507725176595);
-        assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
-        assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
-        assert!(approx_eq!(
-            f64,
-            transaction.cummulative_quote_qty,
-            0.0,
-            ulps = 2
-        ));
-        assert!(approx_eq!(f64, transaction.stop_price, 0.09, ulps = 2));
-        assert_eq!(transaction.status, "NEW");
-        assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
-        assert_eq!(transaction.type_name, "STOP_LOSS_LIMIT");
-        assert_eq!(transaction.side, "SELL");
-    }
+    assert_eq!(transaction.symbol, "LTCBTC");
+    assert_eq!(transaction.order_id, 1);
+    assert_eq!(transaction.order_list_id.unwrap(), -1);
+    assert_eq!(transaction.client_order_id, "6gCrw2kRUAF9CvJDGP16IP");
+    assert_eq!(transaction.transact_time, 1507725176595);
+    assert!(approx_eq!(f64, transaction.price, 0.1, ulps = 2));
+    assert!(approx_eq!(f64, transaction.orig_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(f64, transaction.executed_qty, 1.0, ulps = 2));
+    assert!(approx_eq!(
+        f64,
+        transaction.cummulative_quote_qty,
+        0.0,
+        ulps = 2
+    ));
+    assert!(approx_eq!(f64, transaction.stop_price, 0.09, ulps = 2));
+    assert_eq!(transaction.status, "NEW");
+    assert_eq!(transaction.time_in_force, "GTC"); //Migrate to TimeInForce enum
+    assert_eq!(transaction.type_name, "STOP_LOSS_LIMIT");
+    assert_eq!(transaction.side, "SELL");
+}
 
-    #[test]
-    fn test_custom_order() {
-        let mock_test_custom_order = mock("POST", "/api/v3/order/test")
+#[test]
+fn test_custom_order() {
+    let mock_test_custom_order = mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=MARKET".into()))
             .with_body("{}")
             .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account
-            .test_custom_order(
-                "LTCBTC",
-                1,
-                0.1,
-                None,
-                OrderSide::Buy,
-                OrderType::Market,
-                TimeInForce::GTC,
-                None,
-            )
-            .unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account
+        .test_custom_order(
+            "LTCBTC",
+            1,
+            0.1,
+            None,
+            OrderSide::Buy,
+            OrderType::Market,
+            TimeInForce::GTC,
+            None,
+        )
+        .unwrap();
 
-        mock_test_custom_order.assert();
-    }
+    mock_test_custom_order.assert();
+}
 
-    #[test]
-    fn cancel_order() {
-        let mock_cancel_order = mock("DELETE", "/api/v3/order")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "orderId=1&recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
-            ))
-            .with_body_from_file("tests/mocks/account/cancel_order.json")
-            .create();
+#[test]
+fn cancel_order() {
+    let mock_cancel_order = mock("DELETE", "/api/v3/order")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "orderId=1&recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/cancel_order.json")
+        .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let cancelled_order = account.cancel_order("BTCUSDT", 1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let cancelled_order = account.cancel_order("BTCUSDT", 1).unwrap();
 
-        mock_cancel_order.assert();
+    mock_cancel_order.assert();
 
-        assert_eq!(cancelled_order.symbol, "LTCBTC");
-        assert_eq!(cancelled_order.orig_client_order_id.unwrap(), "myOrder1");
-        assert_eq!(cancelled_order.order_id.unwrap(), 4);
-        assert_eq!(cancelled_order.client_order_id.unwrap(), "cancelMyOrder1");
-    }
+    assert_eq!(cancelled_order.symbol, "LTCBTC");
+    assert_eq!(cancelled_order.orig_client_order_id.unwrap(), "myOrder1");
+    assert_eq!(cancelled_order.order_id.unwrap(), 4);
+    assert_eq!(cancelled_order.client_order_id.unwrap(), "cancelMyOrder1");
+}
 
-    #[test]
-    fn test_cancel_order() {
-        let mock_test_cancel_order = mock("DELETE", "/api/v3/order/test")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "orderId=1&recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
-            ))
-            .with_body_from_file("tests/mocks/account/cancel_order.json")
-            .create();
+#[test]
+fn test_cancel_order() {
+    let mock_test_cancel_order = mock("DELETE", "/api/v3/order/test")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "orderId=1&recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/cancel_order.json")
+        .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account.test_cancel_order("BTCUSDT", 1).unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account.test_cancel_order("BTCUSDT", 1).unwrap();
 
-        mock_test_cancel_order.assert();
-    }
+    mock_test_cancel_order.assert();
+}
 
-    #[test]
-    fn trade_history() {
-        let mock_trade_history = mock("GET", "/api/v3/myTrades")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
-            ))
-            .with_body_from_file("tests/mocks/account/trade_history.json")
-            .create();
+#[test]
+fn trade_history() {
+    let mock_trade_history = mock("GET", "/api/v3/myTrades")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
+        ))
+        .with_body_from_file("tests/mocks/account/trade_history.json")
+        .create();
 
-        let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: Account = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let histories = account.trade_history("BTCUSDT").unwrap();
+    let config = Config::default()
+        .set_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: Account = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let histories = account.trade_history("BTCUSDT").unwrap();
 
-        mock_trade_history.assert();
+    mock_trade_history.assert();
 
-        assert!(histories.len() == 1);
+    assert!(histories.len() == 1);
 
-        let history: TradeHistory = histories[0].clone();
+    let history: TradeHistory = histories[0].clone();
 
-        assert_eq!(history.id, 28457);
-        assert!(approx_eq!(f64, history.price, 4.00000100, ulps = 2));
-        assert!(approx_eq!(f64, history.qty, 12.00000000, ulps = 2));
-        assert_eq!(history.commission, "10.10000000");
-        assert_eq!(history.commission_asset, "BNB");
-        assert_eq!(history.time, 1499865549590);
-        assert!(history.is_buyer);
-        assert!(!history.is_maker);
-        assert!(history.is_best_match);
-    }
+    assert_eq!(history.id, 28457);
+    assert!(approx_eq!(f64, history.price, 4.00000100, ulps = 2));
+    assert!(approx_eq!(f64, history.qty, 12.00000000, ulps = 2));
+    assert_eq!(history.commission, "10.10000000");
+    assert_eq!(history.commission_asset, "BNB");
+    assert_eq!(history.time, 1499865549590);
+    assert!(history.is_buyer);
+    assert!(!history.is_maker);
+    assert!(history.is_best_match);
 }

--- a/tests/futures_account_tests.rs
+++ b/tests/futures_account_tests.rs
@@ -1,169 +1,164 @@
-use binance::api::*;
-use binance::config::*;
-use binance::futures::account::*;
+use binance::api::Binance;
+use binance::config::Config;
+use binance::futures::account::{CustomOrderRequest, FuturesAccount, OrderType};
+use mockito::{mock, Matcher};
+use float_cmp::approx_eq;
+use binance::account::OrderSide;
+use binance::futures::model::Transaction;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use mockito::{mock, Matcher};
-    use float_cmp::*;
-    use binance::account::OrderSide;
-    use binance::futures::model::Transaction;
+#[test]
+fn change_initial_leverage() {
+    let mock_change_leverage = mock("POST", "/fapi/v1/leverage")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "leverage=2&recvWindow=1234&symbol=LTCUSDT&timestamp=\\d+&signature=.*".into(),
+        ))
+        .with_body_from_file("tests/mocks/futures/account/change_initial_leverage.json")
+        .create();
 
-    #[test]
-    fn change_initial_leverage() {
-        let mock_change_leverage = mock("POST", "/fapi/v1/leverage")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "leverage=2&recvWindow=1234&symbol=LTCUSDT&timestamp=\\d+&signature=.*".into(),
-            ))
-            .with_body_from_file("tests/mocks/futures/account/change_initial_leverage.json")
-            .create();
+    let config = Config::default()
+        .set_futures_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: FuturesAccount = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let response = account.change_initial_leverage("LTCUSDT", 2).unwrap();
 
-        let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: FuturesAccount = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let response = account.change_initial_leverage("LTCUSDT", 2).unwrap();
+    mock_change_leverage.assert();
 
-        mock_change_leverage.assert();
+    assert_eq!(response.leverage, 2);
+    assert_eq!(response.symbol, "LTCUSDT");
+    assert!(approx_eq!(
+        f64,
+        response.max_notional_value,
+        9223372036854776000.0,
+        ulps = 2
+    ));
+}
 
-        assert_eq!(response.leverage, 2);
-        assert_eq!(response.symbol, "LTCUSDT");
-        assert!(approx_eq!(
-            f64,
-            response.max_notional_value,
-            9223372036854776000.0,
-            ulps = 2
-        ));
-    }
+#[test]
+fn cancel_all_open_orders() {
+    let mock = mock("DELETE", "/fapi/v1/allOpenOrders")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+&signature=.*".into(),
+        ))
+        .with_body_from_file("tests/mocks/futures/account/cancel_all_open_orders.json")
+        .create();
 
-    #[test]
-    fn cancel_all_open_orders() {
-        let mock = mock("DELETE", "/fapi/v1/allOpenOrders")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+&signature=.*".into(),
-            ))
-            .with_body_from_file("tests/mocks/futures/account/cancel_all_open_orders.json")
-            .create();
+    let config = Config::default()
+        .set_futures_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: FuturesAccount = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account.cancel_all_open_orders("BTCUSDT").unwrap();
 
-        let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: FuturesAccount = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account.cancel_all_open_orders("BTCUSDT").unwrap();
+    mock.assert();
+}
 
-        mock.assert();
-    }
+#[test]
+fn change_position_mode() {
+    let mock = mock("POST", "/fapi/v1/positionSide/dual")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex(
+            "dualSidePosition=true&recvWindow=1234&timestamp=\\d+&signature=.*".into(),
+        ))
+        .with_body_from_file("tests/mocks/futures/account/change_position_mode.json")
+        .create();
 
-    #[test]
-    fn change_position_mode() {
-        let mock = mock("POST", "/fapi/v1/positionSide/dual")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex(
-                "dualSidePosition=true&recvWindow=1234&timestamp=\\d+&signature=.*".into(),
-            ))
-            .with_body_from_file("tests/mocks/futures/account/change_position_mode.json")
-            .create();
+    let config = Config::default()
+        .set_futures_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: FuturesAccount = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    account.change_position_mode(true).unwrap();
 
-        let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: FuturesAccount = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        account.change_position_mode(true).unwrap();
+    mock.assert();
+}
 
-        mock.assert();
-    }
-
-    #[test]
-    fn stop_market_close_buy() {
-        let mock_stop_market_close_sell = mock("POST", "/fapi/v1/order")
+#[test]
+fn stop_market_close_buy() {
+    let mock_stop_market_close_sell = mock("POST", "/fapi/v1/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("closePosition=TRUE&recvWindow=1234&side=BUY&stopPrice=10.5&symbol=SRMUSDT&timestamp=\\d+&type=STOP_MARKET".into()))
             .with_body_from_file("tests/mocks/futures/account/stop_market_close_position_buy.json")
             .create();
 
-        let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: FuturesAccount = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let transaction: Transaction = account.stop_market_close_buy("SRMUSDT", 10.5).unwrap();
+    let config = Config::default()
+        .set_futures_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: FuturesAccount = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let transaction: Transaction = account.stop_market_close_buy("SRMUSDT", 10.5).unwrap();
 
-        mock_stop_market_close_sell.assert();
+    mock_stop_market_close_sell.assert();
 
-        assert_eq!(transaction.symbol, "SRMUSDT");
-        assert_eq!(transaction.side, "BUY");
-        assert_eq!(transaction.orig_type, "STOP_MARKET");
-        assert!(transaction.close_position);
-        assert!(approx_eq!(f64, transaction.stop_price, 10.5, ulps = 2));
-    }
+    assert_eq!(transaction.symbol, "SRMUSDT");
+    assert_eq!(transaction.side, "BUY");
+    assert_eq!(transaction.orig_type, "STOP_MARKET");
+    assert!(transaction.close_position);
+    assert!(approx_eq!(f64, transaction.stop_price, 10.5, ulps = 2));
+}
 
-    #[test]
-    fn stop_market_close_sell() {
-        let mock_stop_market_close_sell = mock("POST", "/fapi/v1/order")
+#[test]
+fn stop_market_close_sell() {
+    let mock_stop_market_close_sell = mock("POST", "/fapi/v1/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("closePosition=TRUE&recvWindow=1234&side=SELL&stopPrice=7.4&symbol=SRMUSDT&timestamp=\\d+&type=STOP_MARKET".into()))
             .with_body_from_file("tests/mocks/futures/account/stop_market_close_position_sell.json")
             .create();
 
-        let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: FuturesAccount = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let transaction: Transaction = account.stop_market_close_sell("SRMUSDT", 7.4).unwrap();
+    let config = Config::default()
+        .set_futures_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: FuturesAccount = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let transaction: Transaction = account.stop_market_close_sell("SRMUSDT", 7.4).unwrap();
 
-        mock_stop_market_close_sell.assert();
+    mock_stop_market_close_sell.assert();
 
-        assert_eq!(transaction.symbol, "SRMUSDT");
-        assert_eq!(transaction.side, "SELL");
-        assert_eq!(transaction.orig_type, "STOP_MARKET");
-        assert!(transaction.close_position);
-        assert!(approx_eq!(f64, transaction.stop_price, 7.4, ulps = 2));
-    }
+    assert_eq!(transaction.symbol, "SRMUSDT");
+    assert_eq!(transaction.side, "SELL");
+    assert_eq!(transaction.orig_type, "STOP_MARKET");
+    assert!(transaction.close_position);
+    assert!(approx_eq!(f64, transaction.stop_price, 7.4, ulps = 2));
+}
 
-    #[test]
-    fn custom_order() {
-        let mock_custom_order = mock("POST", "/fapi/v1/order")
+#[test]
+fn custom_order() {
+    let mock_custom_order = mock("POST", "/fapi/v1/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("closePosition=TRUE&recvWindow=1234&side=SELL&stopPrice=7.4&symbol=SRMUSDT&timestamp=\\d+&type=STOP_MARKET".into()))
             .with_body_from_file("tests/mocks/futures/account/stop_market_close_position_sell.json")
             .create();
 
-        let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
-            .set_recv_window(1234);
-        let account: FuturesAccount = Binance::new_with_config(None, None, &config);
-        let _ = env_logger::try_init();
-        let custom_order = CustomOrderRequest {
-            symbol: "SRMUSDT".into(),
-            side: OrderSide::Sell,
-            position_side: None,
-            order_type: OrderType::StopMarket,
-            time_in_force: None,
-            qty: None,
-            reduce_only: None,
-            price: None,
-            stop_price: Some(7.4),
-            close_position: Some(true),
-            activation_price: None,
-            callback_rate: None,
-            working_type: None,
-            price_protect: None,
-        };
-        let transaction: Transaction = account.custom_order(custom_order).unwrap();
+    let config = Config::default()
+        .set_futures_rest_api_endpoint(mockito::server_url())
+        .set_recv_window(1234);
+    let account: FuturesAccount = Binance::new_with_config(None, None, &config);
+    let _ = env_logger::try_init();
+    let custom_order = CustomOrderRequest {
+        symbol: "SRMUSDT".into(),
+        side: OrderSide::Sell,
+        position_side: None,
+        order_type: OrderType::StopMarket,
+        time_in_force: None,
+        qty: None,
+        reduce_only: None,
+        price: None,
+        stop_price: Some(7.4),
+        close_position: Some(true),
+        activation_price: None,
+        callback_rate: None,
+        working_type: None,
+        price_protect: None,
+    };
+    let transaction: Transaction = account.custom_order(custom_order).unwrap();
 
-        mock_custom_order.assert();
+    mock_custom_order.assert();
 
-        assert_eq!(transaction.symbol, "SRMUSDT");
-        assert_eq!(transaction.side, "SELL");
-        assert_eq!(transaction.orig_type, "STOP_MARKET");
-        assert!(transaction.close_position);
-        assert!(approx_eq!(f64, transaction.stop_price, 7.4, ulps = 2));
-    }
+    assert_eq!(transaction.symbol, "SRMUSDT");
+    assert_eq!(transaction.side, "SELL");
+    assert_eq!(transaction.orig_type, "STOP_MARKET");
+    assert!(transaction.close_position);
+    assert!(approx_eq!(f64, transaction.stop_price, 7.4, ulps = 2));
 }

--- a/tests/futures_market_test.rs
+++ b/tests/futures_market_test.rs
@@ -1,44 +1,39 @@
-use binance::api::*;
-use binance::config::*;
+use binance::api::Binance;
+use binance::config::Config;
 use binance::futures::market::FuturesMarket;
 use binance::futures::model::OpenInterestHist;
+use mockito::{mock, Matcher};
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use mockito::{mock, Matcher};
+#[test]
+fn open_interest_statistics() {
+    let mock_open_interest_statistics = mock("GET", "/futures/data/openInterestHist")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex("limit=10&period=5m&symbol=BTCUSDT".into()))
+        .with_body_from_file("tests/mocks/futures/market/open_interest_statistics.json")
+        .create();
 
-    #[test]
-    fn open_interest_statistics() {
-        let mock_open_interest_statistics = mock("GET", "/futures/data/openInterestHist")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("limit=10&period=5m&symbol=BTCUSDT".into()))
-            .with_body_from_file("tests/mocks/futures/market/open_interest_statistics.json")
-            .create();
+    let config = Config::default().set_futures_rest_api_endpoint(mockito::server_url());
+    let market: FuturesMarket = Binance::new_with_config(None, None, &config);
 
-        let config = Config::default().set_futures_rest_api_endpoint(mockito::server_url());
-        let market: FuturesMarket = Binance::new_with_config(None, None, &config);
+    let open_interest_hists = market
+        .open_interest_statistics("BTCUSDT", "5m", 10, None, None)
+        .unwrap();
+    mock_open_interest_statistics.assert();
 
-        let open_interest_hists = market
-            .open_interest_statistics("BTCUSDT", "5m", 10, None, None)
-            .unwrap();
-        mock_open_interest_statistics.assert();
+    let expectation = vec![
+        OpenInterestHist {
+            symbol: "BTCUSDT".into(),
+            sum_open_interest: "20403.63700000".into(),
+            sum_open_interest_value: "150570784.07809979".into(),
+            timestamp: 1583127900000,
+        },
+        OpenInterestHist {
+            symbol: "BTCUSDT".into(),
+            sum_open_interest: "20401.36700000".into(),
+            sum_open_interest_value: "149940752.14464448".into(),
+            timestamp: 1583128200000,
+        },
+    ];
 
-        let expectation = vec![
-            OpenInterestHist {
-                symbol: "BTCUSDT".into(),
-                sum_open_interest: "20403.63700000".into(),
-                sum_open_interest_value: "150570784.07809979".into(),
-                timestamp: 1583127900000,
-            },
-            OpenInterestHist {
-                symbol: "BTCUSDT".into(),
-                sum_open_interest: "20401.36700000".into(),
-                sum_open_interest_value: "149940752.14464448".into(),
-                timestamp: 1583128200000,
-            },
-        ];
-
-        assert_eq!(open_interest_hists, expectation)
-    }
+    assert_eq!(open_interest_hists, expectation)
 }

--- a/tests/general_tests.rs
+++ b/tests/general_tests.rs
@@ -1,157 +1,152 @@
-use binance::api::*;
-use binance::config::*;
-use binance::general::*;
-use binance::model::*;
+use binance::api::Binance;
+use binance::config::Config;
+use binance::general::General;
+use binance::model::Filters;
+use mockito::mock;
+use float_cmp::approx_eq;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use mockito::mock;
-    use float_cmp::*;
+#[test]
+fn ping() {
+    let mock_ping = mock("GET", "/api/v3/ping")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .with_body("{}")
+        .create();
 
-    #[test]
-    fn ping() {
-        let mock_ping = mock("GET", "/api/v3/ping")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .with_body("{}")
-            .create();
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let general: General = Binance::new_with_config(None, None, &config);
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let general: General = Binance::new_with_config(None, None, &config);
+    let pong = general.ping().unwrap();
+    mock_ping.assert();
 
-        let pong = general.ping().unwrap();
-        mock_ping.assert();
+    assert_eq!(pong, "pong");
+}
 
-        assert_eq!(pong, "pong");
-    }
+#[test]
+fn get_server_time() {
+    let mock_server_time = mock("GET", "/api/v3/time")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .with_body_from_file("tests/mocks/general/server_time.json")
+        .create();
 
-    #[test]
-    fn get_server_time() {
-        let mock_server_time = mock("GET", "/api/v3/time")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .with_body_from_file("tests/mocks/general/server_time.json")
-            .create();
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let general: General = Binance::new_with_config(None, None, &config);
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let general: General = Binance::new_with_config(None, None, &config);
+    let server_time = general.get_server_time().unwrap();
+    mock_server_time.assert();
 
-        let server_time = general.get_server_time().unwrap();
-        mock_server_time.assert();
+    assert_eq!(server_time.server_time, 1499827319559);
+}
 
-        assert_eq!(server_time.server_time, 1499827319559);
-    }
+#[test]
+fn exchange_info() {
+    let mock_exchange_info = mock("GET", "/api/v3/exchangeInfo")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .with_body_from_file("tests/mocks/general/exchange_info.json")
+        .create();
 
-    #[test]
-    fn exchange_info() {
-        let mock_exchange_info = mock("GET", "/api/v3/exchangeInfo")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .with_body_from_file("tests/mocks/general/exchange_info.json")
-            .create();
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let general: General = Binance::new_with_config(None, None, &config);
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let general: General = Binance::new_with_config(None, None, &config);
+    let exchange_info = general.exchange_info().unwrap();
+    mock_exchange_info.assert();
 
-        let exchange_info = general.exchange_info().unwrap();
-        mock_exchange_info.assert();
+    assert!(exchange_info.symbols.len() > 1);
+}
 
-        assert!(exchange_info.symbols.len() > 1);
-    }
+#[test]
+fn get_symbol_info() {
+    let mock_exchange_info = mock("GET", "/api/v3/exchangeInfo")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .with_body_from_file("tests/mocks/general/exchange_info.json")
+        .create();
 
-    #[test]
-    fn get_symbol_info() {
-        let mock_exchange_info = mock("GET", "/api/v3/exchangeInfo")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .with_body_from_file("tests/mocks/general/exchange_info.json")
-            .create();
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let general: General = Binance::new_with_config(None, None, &config);
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let general: General = Binance::new_with_config(None, None, &config);
+    let symbol = general.get_symbol_info("BNBBTC").unwrap();
+    mock_exchange_info.assert();
 
-        let symbol = general.get_symbol_info("BNBBTC").unwrap();
-        mock_exchange_info.assert();
+    assert_eq!(symbol.symbol, "BNBBTC");
+    assert_eq!(symbol.status, "TRADING");
+    assert_eq!(symbol.base_asset, "BNB");
+    assert_eq!(symbol.base_asset_precision, 8);
+    assert_eq!(symbol.quote_asset, "BTC");
+    assert_eq!(symbol.quote_precision, 8);
 
-        assert_eq!(symbol.symbol, "BNBBTC");
-        assert_eq!(symbol.status, "TRADING");
-        assert_eq!(symbol.base_asset, "BNB");
-        assert_eq!(symbol.base_asset_precision, 8);
-        assert_eq!(symbol.quote_asset, "BTC");
-        assert_eq!(symbol.quote_precision, 8);
+    assert!(!symbol.order_types.is_empty());
+    assert_eq!(symbol.order_types[0], "LIMIT");
+    assert_eq!(symbol.order_types[1], "LIMIT_MAKER");
+    assert_eq!(symbol.order_types[2], "MARKET");
+    assert_eq!(symbol.order_types[3], "STOP_LOSS_LIMIT");
+    assert_eq!(symbol.order_types[4], "TAKE_PROFIT_LIMIT");
 
-        assert!(!symbol.order_types.is_empty());
-        assert_eq!(symbol.order_types[0], "LIMIT");
-        assert_eq!(symbol.order_types[1], "LIMIT_MAKER");
-        assert_eq!(symbol.order_types[2], "MARKET");
-        assert_eq!(symbol.order_types[3], "STOP_LOSS_LIMIT");
-        assert_eq!(symbol.order_types[4], "TAKE_PROFIT_LIMIT");
+    assert!(symbol.iceberg_allowed);
+    assert!(symbol.is_spot_trading_allowed);
+    assert!(symbol.is_margin_trading_allowed);
 
-        assert!(symbol.iceberg_allowed);
-        assert!(symbol.is_spot_trading_allowed);
-        assert!(symbol.is_margin_trading_allowed);
+    assert!(!symbol.filters.is_empty());
 
-        assert!(!symbol.filters.is_empty());
-
-        for filter in symbol.filters.into_iter() {
-            match filter {
-                Filters::PriceFilter {
-                    min_price,
-                    max_price,
-                    tick_size,
-                } => {
-                    assert_eq!(min_price, "0.00000010");
-                    assert_eq!(max_price, "100000.00000000");
-                    assert_eq!(tick_size, "0.00000010");
-                }
-                Filters::PercentPrice {
-                    multiplier_up,
-                    multiplier_down,
-                    avg_price_mins,
-                } => {
-                    assert_eq!(multiplier_up, "5");
-                    assert_eq!(multiplier_down, "0.2");
-                    assert!(approx_eq!(f64, avg_price_mins.unwrap(), 5.0, ulps = 2));
-                }
-                Filters::LotSize {
-                    min_qty,
-                    max_qty,
-                    step_size,
-                } => {
-                    assert_eq!(min_qty, "0.01000000");
-                    assert_eq!(max_qty, "100000.00000000");
-                    assert_eq!(step_size, "0.01000000");
-                }
-                Filters::MinNotional {
-                    notional,
-                    min_notional,
-                    apply_to_market,
-                    avg_price_mins,
-                } => {
-                    assert!(notional.is_none());
-                    assert_eq!(min_notional.unwrap(), "0.00010000");
-                    assert!(apply_to_market.unwrap());
-                    assert!(approx_eq!(f64, avg_price_mins.unwrap(), 5.0, ulps = 2));
-                }
-                Filters::IcebergParts { limit } => {
-                    assert_eq!(limit.unwrap(), 10);
-                }
-                Filters::MarketLotSize {
-                    min_qty,
-                    max_qty,
-                    step_size,
-                } => {
-                    assert_eq!(min_qty, "0.00000000");
-                    assert_eq!(max_qty, "8528.32329395");
-                    assert_eq!(step_size, "0.00000000");
-                }
-                Filters::MaxNumOrders { max_num_orders } => {
-                    assert_eq!(max_num_orders.unwrap(), 200);
-                }
-                Filters::MaxNumAlgoOrders {
-                    max_num_algo_orders,
-                } => {
-                    assert_eq!(max_num_algo_orders.unwrap(), 5);
-                }
-                _ => panic!(),
+    for filter in symbol.filters.into_iter() {
+        match filter {
+            Filters::PriceFilter {
+                min_price,
+                max_price,
+                tick_size,
+            } => {
+                assert_eq!(min_price, "0.00000010");
+                assert_eq!(max_price, "100000.00000000");
+                assert_eq!(tick_size, "0.00000010");
             }
+            Filters::PercentPrice {
+                multiplier_up,
+                multiplier_down,
+                avg_price_mins,
+            } => {
+                assert_eq!(multiplier_up, "5");
+                assert_eq!(multiplier_down, "0.2");
+                assert!(approx_eq!(f64, avg_price_mins.unwrap(), 5.0, ulps = 2));
+            }
+            Filters::LotSize {
+                min_qty,
+                max_qty,
+                step_size,
+            } => {
+                assert_eq!(min_qty, "0.01000000");
+                assert_eq!(max_qty, "100000.00000000");
+                assert_eq!(step_size, "0.01000000");
+            }
+            Filters::MinNotional {
+                notional,
+                min_notional,
+                apply_to_market,
+                avg_price_mins,
+            } => {
+                assert!(notional.is_none());
+                assert_eq!(min_notional.unwrap(), "0.00010000");
+                assert!(apply_to_market.unwrap());
+                assert!(approx_eq!(f64, avg_price_mins.unwrap(), 5.0, ulps = 2));
+            }
+            Filters::IcebergParts { limit } => {
+                assert_eq!(limit.unwrap(), 10);
+            }
+            Filters::MarketLotSize {
+                min_qty,
+                max_qty,
+                step_size,
+            } => {
+                assert_eq!(min_qty, "0.00000000");
+                assert_eq!(max_qty, "8528.32329395");
+                assert_eq!(step_size, "0.00000000");
+            }
+            Filters::MaxNumOrders { max_num_orders } => {
+                assert_eq!(max_num_orders.unwrap(), 200);
+            }
+            Filters::MaxNumAlgoOrders {
+                max_num_algo_orders,
+            } => {
+                assert_eq!(max_num_algo_orders.unwrap(), 5);
+            }
+            _ => panic!(),
         }
     }
 }

--- a/tests/market_tests.rs
+++ b/tests/market_tests.rs
@@ -1,335 +1,330 @@
-use binance::api::*;
-use binance::config::*;
-use binance::market::*;
-use binance::model::*;
+use binance::api::Binance;
+use binance::config::Config;
+use binance::market::Market;
+use binance::model::{Bids, KlineSummary, Prices};
+use float_cmp::approx_eq;
+use mockito::{mock, Matcher};
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use mockito::{mock, Matcher};
-    use float_cmp::*;
+#[test]
+fn get_depth() {
+    let mock_get_depth = mock("GET", "/api/v3/depth")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex("symbol=LTCBTC".into()))
+        .with_body_from_file("tests/mocks/market/get_depth.json")
+        .create();
 
-    #[test]
-    fn get_depth() {
-        let mock_get_depth = mock("GET", "/api/v3/depth")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("symbol=LTCBTC".into()))
-            .with_body_from_file("tests/mocks/market/get_depth.json")
-            .create();
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let order_book = market.get_depth("LTCBTC").unwrap();
+    mock_get_depth.assert();
 
-        let order_book = market.get_depth("LTCBTC").unwrap();
-        mock_get_depth.assert();
+    assert_eq!(order_book.last_update_id, 1027024);
+    assert_eq!(order_book.bids[0], Bids::new(4.00000000, 431.00000000));
+}
 
-        assert_eq!(order_book.last_update_id, 1027024);
-        assert_eq!(order_book.bids[0], Bids::new(4.00000000, 431.00000000));
-    }
+#[test]
+fn get_custom_depth() {
+    let mock_get_custom_depth = mock("GET", "/api/v3/depth")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex("limit=10&symbol=LTCBTC".into()))
+        .with_body_from_file("tests/mocks/market/get_depth.json")
+        .create();
 
-    #[test]
-    fn get_custom_depth() {
-        let mock_get_custom_depth = mock("GET", "/api/v3/depth")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("limit=10&symbol=LTCBTC".into()))
-            .with_body_from_file("tests/mocks/market/get_depth.json")
-            .create();
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let order_book = market.get_custom_depth("LTCBTC", 10).unwrap();
+    mock_get_custom_depth.assert();
 
-        let order_book = market.get_custom_depth("LTCBTC", 10).unwrap();
-        mock_get_custom_depth.assert();
+    assert_eq!(order_book.last_update_id, 1027024);
+    assert_eq!(order_book.bids[0], Bids::new(4.00000000, 431.00000000));
+}
 
-        assert_eq!(order_book.last_update_id, 1027024);
-        assert_eq!(order_book.bids[0], Bids::new(4.00000000, 431.00000000));
-    }
+#[test]
+fn get_all_prices() {
+    let mock_get_all_prices = mock("GET", "/api/v3/ticker/price")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .with_body_from_file("tests/mocks/market/get_all_prices.json")
+        .create();
 
-    #[test]
-    fn get_all_prices() {
-        let mock_get_all_prices = mock("GET", "/api/v3/ticker/price")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .with_body_from_file("tests/mocks/market/get_all_prices.json")
-            .create();
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let prices: Prices = market.get_all_prices().unwrap();
+    mock_get_all_prices.assert();
 
-        let prices: Prices = market.get_all_prices().unwrap();
-        mock_get_all_prices.assert();
-
-        match prices {
-            binance::model::Prices::AllPrices(symbols) => {
-                assert!(!symbols.is_empty());
-                let first_symbol = symbols[0].clone();
-                assert_eq!(first_symbol.symbol, "LTCBTC");
-                assert!(approx_eq!(f64, first_symbol.price, 4.00000200, ulps = 2));
-                let second_symbol = symbols[1].clone();
-                assert_eq!(second_symbol.symbol, "ETHBTC");
-                assert!(approx_eq!(f64, second_symbol.price, 0.07946600, ulps = 2));
-            }
+    match prices {
+        binance::model::Prices::AllPrices(symbols) => {
+            assert!(!symbols.is_empty());
+            let first_symbol = symbols[0].clone();
+            assert_eq!(first_symbol.symbol, "LTCBTC");
+            assert!(approx_eq!(f64, first_symbol.price, 4.00000200, ulps = 2));
+            let second_symbol = symbols[1].clone();
+            assert_eq!(second_symbol.symbol, "ETHBTC");
+            assert!(approx_eq!(f64, second_symbol.price, 0.07946600, ulps = 2));
         }
     }
+}
 
-    #[test]
-    fn get_price() {
-        let mock_get_price = mock("GET", "/api/v3/ticker/price")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("symbol=LTCBTC".into()))
-            .with_body_from_file("tests/mocks/market/get_price.json")
-            .create();
+#[test]
+fn get_price() {
+    let mock_get_price = mock("GET", "/api/v3/ticker/price")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex("symbol=LTCBTC".into()))
+        .with_body_from_file("tests/mocks/market/get_price.json")
+        .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let symbol = market.get_price("LTCBTC").unwrap();
-        mock_get_price.assert();
+    let symbol = market.get_price("LTCBTC").unwrap();
+    mock_get_price.assert();
 
-        assert_eq!(symbol.symbol, "LTCBTC");
-        assert!(approx_eq!(f64, symbol.price, 4.00000200, ulps = 2));
-    }
+    assert_eq!(symbol.symbol, "LTCBTC");
+    assert!(approx_eq!(f64, symbol.price, 4.00000200, ulps = 2));
+}
 
-    #[test]
-    fn get_average_price() {
-        let mock_get_average_price = mock("GET", "/api/v3/avgPrice")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("symbol=LTCBTC".into()))
-            .with_body_from_file("tests/mocks/market/get_average_price.json")
-            .create();
+#[test]
+fn get_average_price() {
+    let mock_get_average_price = mock("GET", "/api/v3/avgPrice")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex("symbol=LTCBTC".into()))
+        .with_body_from_file("tests/mocks/market/get_average_price.json")
+        .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let symbol = market.get_average_price("LTCBTC").unwrap();
-        mock_get_average_price.assert();
+    let symbol = market.get_average_price("LTCBTC").unwrap();
+    mock_get_average_price.assert();
 
-        assert_eq!(symbol.mins, 5);
-        assert!(approx_eq!(f64, symbol.price, 9.35751834, ulps = 2));
-    }
+    assert_eq!(symbol.mins, 5);
+    assert!(approx_eq!(f64, symbol.price, 9.35751834, ulps = 2));
+}
 
-    #[test]
-    fn get_all_book_tickers() {
-        let mock_get_all_book_tickers = mock("GET", "/api/v3/ticker/bookTicker")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .with_body_from_file("tests/mocks/market/get_all_book_tickers.json")
-            .create();
+#[test]
+fn get_all_book_tickers() {
+    let mock_get_all_book_tickers = mock("GET", "/api/v3/ticker/bookTicker")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .with_body_from_file("tests/mocks/market/get_all_book_tickers.json")
+        .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let book_tickers = market.get_all_book_tickers().unwrap();
-        mock_get_all_book_tickers.assert();
+    let book_tickers = market.get_all_book_tickers().unwrap();
+    mock_get_all_book_tickers.assert();
 
-        match book_tickers {
-            binance::model::BookTickers::AllBookTickers(tickers) => {
-                assert!(!tickers.is_empty());
-                let first_ticker = tickers[0].clone();
-                assert_eq!(first_ticker.symbol, "LTCBTC");
-                assert!(approx_eq!(
-                    f64,
-                    first_ticker.bid_price,
-                    4.00000000,
-                    ulps = 2
-                ));
-                assert!(approx_eq!(
-                    f64,
-                    first_ticker.bid_qty,
-                    431.00000000,
-                    ulps = 2
-                ));
-                assert!(approx_eq!(
-                    f64,
-                    first_ticker.ask_price,
-                    4.00000200,
-                    ulps = 2
-                ));
-                assert!(approx_eq!(f64, first_ticker.ask_qty, 9.00000000, ulps = 2));
-                let second_ticker = tickers[1].clone();
-                assert_eq!(second_ticker.symbol, "ETHBTC");
-                assert!(approx_eq!(
-                    f64,
-                    second_ticker.bid_price,
-                    0.07946700,
-                    ulps = 2
-                ));
-                assert!(approx_eq!(f64, second_ticker.bid_qty, 9.00000000, ulps = 2));
-                assert!(approx_eq!(
-                    f64,
-                    second_ticker.ask_price,
-                    100000.00000000,
-                    ulps = 2
-                ));
-                assert!(approx_eq!(
-                    f64,
-                    second_ticker.ask_qty,
-                    1000.00000000,
-                    ulps = 2
-                ));
-            }
+    match book_tickers {
+        binance::model::BookTickers::AllBookTickers(tickers) => {
+            assert!(!tickers.is_empty());
+            let first_ticker = tickers[0].clone();
+            assert_eq!(first_ticker.symbol, "LTCBTC");
+            assert!(approx_eq!(
+                f64,
+                first_ticker.bid_price,
+                4.00000000,
+                ulps = 2
+            ));
+            assert!(approx_eq!(
+                f64,
+                first_ticker.bid_qty,
+                431.00000000,
+                ulps = 2
+            ));
+            assert!(approx_eq!(
+                f64,
+                first_ticker.ask_price,
+                4.00000200,
+                ulps = 2
+            ));
+            assert!(approx_eq!(f64, first_ticker.ask_qty, 9.00000000, ulps = 2));
+            let second_ticker = tickers[1].clone();
+            assert_eq!(second_ticker.symbol, "ETHBTC");
+            assert!(approx_eq!(
+                f64,
+                second_ticker.bid_price,
+                0.07946700,
+                ulps = 2
+            ));
+            assert!(approx_eq!(f64, second_ticker.bid_qty, 9.00000000, ulps = 2));
+            assert!(approx_eq!(
+                f64,
+                second_ticker.ask_price,
+                100000.00000000,
+                ulps = 2
+            ));
+            assert!(approx_eq!(
+                f64,
+                second_ticker.ask_qty,
+                1000.00000000,
+                ulps = 2
+            ));
         }
     }
+}
 
-    #[test]
-    fn get_book_ticker() {
-        let mock_get_book_ticker = mock("GET", "/api/v3/ticker/bookTicker")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("symbol=LTCBTC".into()))
-            .with_body_from_file("tests/mocks/market/get_book_ticker.json")
-            .create();
+#[test]
+fn get_book_ticker() {
+    let mock_get_book_ticker = mock("GET", "/api/v3/ticker/bookTicker")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex("symbol=LTCBTC".into()))
+        .with_body_from_file("tests/mocks/market/get_book_ticker.json")
+        .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let book_ticker = market.get_book_ticker("LTCBTC").unwrap();
-        mock_get_book_ticker.assert();
+    let book_ticker = market.get_book_ticker("LTCBTC").unwrap();
+    mock_get_book_ticker.assert();
 
-        assert_eq!(book_ticker.symbol, "LTCBTC");
-        assert!(approx_eq!(f64, book_ticker.bid_price, 4.00000000, ulps = 2));
-        assert!(approx_eq!(f64, book_ticker.bid_qty, 431.00000000, ulps = 2));
-        assert!(approx_eq!(f64, book_ticker.ask_price, 4.00000200, ulps = 2));
-        assert!(approx_eq!(f64, book_ticker.ask_qty, 9.00000000, ulps = 2));
-    }
+    assert_eq!(book_ticker.symbol, "LTCBTC");
+    assert!(approx_eq!(f64, book_ticker.bid_price, 4.00000000, ulps = 2));
+    assert!(approx_eq!(f64, book_ticker.bid_qty, 431.00000000, ulps = 2));
+    assert!(approx_eq!(f64, book_ticker.ask_price, 4.00000200, ulps = 2));
+    assert!(approx_eq!(f64, book_ticker.ask_qty, 9.00000000, ulps = 2));
+}
 
-    #[test]
-    fn get_24h_price_stats() {
-        let mock_get_24h_price_stats = mock("GET", "/api/v3/ticker/24hr")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("symbol=BNBBTC".into()))
-            .with_body_from_file("tests/mocks/market/get_24h_price_stats.json")
-            .create();
+#[test]
+fn get_24h_price_stats() {
+    let mock_get_24h_price_stats = mock("GET", "/api/v3/ticker/24hr")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex("symbol=BNBBTC".into()))
+        .with_body_from_file("tests/mocks/market/get_24h_price_stats.json")
+        .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let price_stats = market.get_24h_price_stats("BNBBTC").unwrap();
-        mock_get_24h_price_stats.assert();
+    let price_stats = market.get_24h_price_stats("BNBBTC").unwrap();
+    mock_get_24h_price_stats.assert();
 
-        assert_eq!(price_stats.symbol, "BNBBTC");
-        assert_eq!(price_stats.price_change, "-94.99999800");
-        assert_eq!(price_stats.price_change_percent, "-95.960");
-        assert_eq!(price_stats.weighted_avg_price, "0.29628482");
-        assert!(approx_eq!(
-            f64,
-            price_stats.prev_close_price,
-            0.10002000,
-            ulps = 2
-        ));
-        assert!(approx_eq!(
-            f64,
-            price_stats.last_price,
-            4.00000200,
-            ulps = 2
-        ));
-        assert!(approx_eq!(f64, price_stats.bid_price, 4.00000000, ulps = 2));
-        assert!(approx_eq!(f64, price_stats.ask_price, 4.00000200, ulps = 2));
-        assert!(approx_eq!(
-            f64,
-            price_stats.open_price,
-            99.00000000,
-            ulps = 2
-        ));
-        assert!(approx_eq!(
-            f64,
-            price_stats.high_price,
-            100.00000000,
-            ulps = 2
-        ));
-        assert!(approx_eq!(f64, price_stats.low_price, 0.10000000, ulps = 2));
-        assert!(approx_eq!(f64, price_stats.volume, 8913.30000000, ulps = 2));
-        assert_eq!(price_stats.open_time, 1499783499040);
-        assert_eq!(price_stats.close_time, 1499869899040);
-        assert_eq!(price_stats.first_id, 28385);
-        assert_eq!(price_stats.last_id, 28460);
-        assert_eq!(price_stats.count, 76);
-    }
+    assert_eq!(price_stats.symbol, "BNBBTC");
+    assert_eq!(price_stats.price_change, "-94.99999800");
+    assert_eq!(price_stats.price_change_percent, "-95.960");
+    assert_eq!(price_stats.weighted_avg_price, "0.29628482");
+    assert!(approx_eq!(
+        f64,
+        price_stats.prev_close_price,
+        0.10002000,
+        ulps = 2
+    ));
+    assert!(approx_eq!(
+        f64,
+        price_stats.last_price,
+        4.00000200,
+        ulps = 2
+    ));
+    assert!(approx_eq!(f64, price_stats.bid_price, 4.00000000, ulps = 2));
+    assert!(approx_eq!(f64, price_stats.ask_price, 4.00000200, ulps = 2));
+    assert!(approx_eq!(
+        f64,
+        price_stats.open_price,
+        99.00000000,
+        ulps = 2
+    ));
+    assert!(approx_eq!(
+        f64,
+        price_stats.high_price,
+        100.00000000,
+        ulps = 2
+    ));
+    assert!(approx_eq!(f64, price_stats.low_price, 0.10000000, ulps = 2));
+    assert!(approx_eq!(f64, price_stats.volume, 8913.30000000, ulps = 2));
+    assert_eq!(price_stats.open_time, 1499783499040);
+    assert_eq!(price_stats.close_time, 1499869899040);
+    assert_eq!(price_stats.first_id, 28385);
+    assert_eq!(price_stats.last_id, 28460);
+    assert_eq!(price_stats.count, 76);
+}
 
-    #[test]
-    fn get_all_24h_price_stats() {
-        let mock_get_all_24h_price_stats = mock("GET", "/api/v3/ticker/24hr")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .with_body_from_file("tests/mocks/market/get_all_24h_price_stats.json")
-            .create();
+#[test]
+fn get_all_24h_price_stats() {
+    let mock_get_all_24h_price_stats = mock("GET", "/api/v3/ticker/24hr")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .with_body_from_file("tests/mocks/market/get_all_24h_price_stats.json")
+        .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let prices_stats = market.get_all_24h_price_stats().unwrap();
-        mock_get_all_24h_price_stats.assert();
+    let prices_stats = market.get_all_24h_price_stats().unwrap();
+    mock_get_all_24h_price_stats.assert();
 
-        assert!(!prices_stats.is_empty());
+    assert!(!prices_stats.is_empty());
 
-        let price_stats = prices_stats[0].clone();
+    let price_stats = prices_stats[0].clone();
 
-        assert_eq!(price_stats.symbol, "BNBBTC");
-        assert_eq!(price_stats.price_change, "-94.99999800");
-        assert_eq!(price_stats.price_change_percent, "-95.960");
-        assert_eq!(price_stats.weighted_avg_price, "0.29628482");
-        assert!(approx_eq!(
-            f64,
-            price_stats.prev_close_price,
-            0.10002000,
-            ulps = 2
-        ));
-        assert!(approx_eq!(
-            f64,
-            price_stats.last_price,
-            4.00000200,
-            ulps = 2
-        ));
-        assert!(approx_eq!(f64, price_stats.bid_price, 4.00000000, ulps = 2));
-        assert!(approx_eq!(f64, price_stats.ask_price, 4.00000200, ulps = 2));
-        assert!(approx_eq!(
-            f64,
-            price_stats.open_price,
-            99.00000000,
-            ulps = 2
-        ));
-        assert!(approx_eq!(
-            f64,
-            price_stats.high_price,
-            100.00000000,
-            ulps = 2
-        ));
-        assert!(approx_eq!(f64, price_stats.low_price, 0.10000000, ulps = 2));
-        assert!(approx_eq!(f64, price_stats.volume, 8913.30000000, ulps = 2));
-        assert_eq!(price_stats.open_time, 1499783499040);
-        assert_eq!(price_stats.close_time, 1499869899040);
-        assert_eq!(price_stats.first_id, 28385);
-        assert_eq!(price_stats.last_id, 28460);
-        assert_eq!(price_stats.count, 76);
-    }
+    assert_eq!(price_stats.symbol, "BNBBTC");
+    assert_eq!(price_stats.price_change, "-94.99999800");
+    assert_eq!(price_stats.price_change_percent, "-95.960");
+    assert_eq!(price_stats.weighted_avg_price, "0.29628482");
+    assert!(approx_eq!(
+        f64,
+        price_stats.prev_close_price,
+        0.10002000,
+        ulps = 2
+    ));
+    assert!(approx_eq!(
+        f64,
+        price_stats.last_price,
+        4.00000200,
+        ulps = 2
+    ));
+    assert!(approx_eq!(f64, price_stats.bid_price, 4.00000000, ulps = 2));
+    assert!(approx_eq!(f64, price_stats.ask_price, 4.00000200, ulps = 2));
+    assert!(approx_eq!(
+        f64,
+        price_stats.open_price,
+        99.00000000,
+        ulps = 2
+    ));
+    assert!(approx_eq!(
+        f64,
+        price_stats.high_price,
+        100.00000000,
+        ulps = 2
+    ));
+    assert!(approx_eq!(f64, price_stats.low_price, 0.10000000, ulps = 2));
+    assert!(approx_eq!(f64, price_stats.volume, 8913.30000000, ulps = 2));
+    assert_eq!(price_stats.open_time, 1499783499040);
+    assert_eq!(price_stats.close_time, 1499869899040);
+    assert_eq!(price_stats.first_id, 28385);
+    assert_eq!(price_stats.last_id, 28460);
+    assert_eq!(price_stats.count, 76);
+}
 
-    #[test]
-    fn get_klines() {
-        let mock_get_klines = mock("GET", "/api/v3/klines")
-            .with_header("content-type", "application/json;charset=UTF-8")
-            .match_query(Matcher::Regex("interval=5m&limit=10&symbol=LTCBTC".into()))
-            .with_body_from_file("tests/mocks/market/get_klines.json")
-            .create();
+#[test]
+fn get_klines() {
+    let mock_get_klines = mock("GET", "/api/v3/klines")
+        .with_header("content-type", "application/json;charset=UTF-8")
+        .match_query(Matcher::Regex("interval=5m&limit=10&symbol=LTCBTC".into()))
+        .with_body_from_file("tests/mocks/market/get_klines.json")
+        .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
-        let market: Market = Binance::new_with_config(None, None, &config);
+    let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+    let market: Market = Binance::new_with_config(None, None, &config);
 
-        let klines = market.get_klines("LTCBTC", "5m", 10, None, None).unwrap();
-        mock_get_klines.assert();
+    let klines = market.get_klines("LTCBTC", "5m", 10, None, None).unwrap();
+    mock_get_klines.assert();
 
-        match klines {
-            binance::model::KlineSummaries::AllKlineSummaries(klines) => {
-                assert!(!klines.is_empty());
-                let kline: KlineSummary = klines[0].clone();
+    match klines {
+        binance::model::KlineSummaries::AllKlineSummaries(klines) => {
+            assert!(!klines.is_empty());
+            let kline: KlineSummary = klines[0].clone();
 
-                assert_eq!(kline.open_time, 1499040000000);
-                assert_eq!(kline.open, "0.01634790");
-                assert_eq!(kline.high, "0.80000000");
-                assert_eq!(kline.low, "0.01575800");
-                assert_eq!(kline.close, "0.01577100");
-                assert_eq!(kline.volume, "148976.11427815");
-                assert_eq!(kline.close_time, 1499644799999);
-                assert_eq!(kline.quote_asset_volume, "2434.19055334");
-                assert_eq!(kline.number_of_trades, 308);
-                assert_eq!(kline.taker_buy_base_asset_volume, "1756.87402397");
-                assert_eq!(kline.taker_buy_quote_asset_volume, "28.46694368");
-            }
+            assert_eq!(kline.open_time, 1499040000000);
+            assert_eq!(kline.open, "0.01634790");
+            assert_eq!(kline.high, "0.80000000");
+            assert_eq!(kline.low, "0.01575800");
+            assert_eq!(kline.close, "0.01577100");
+            assert_eq!(kline.volume, "148976.11427815");
+            assert_eq!(kline.close_time, 1499644799999);
+            assert_eq!(kline.quote_asset_volume, "2434.19055334");
+            assert_eq!(kline.number_of_trades, 308);
+            assert_eq!(kline.taker_buy_base_asset_volume, "1756.87402397");
+            assert_eq!(kline.taker_buy_quote_asset_volume, "28.46694368");
         }
     }
 }

--- a/tests/util_tests.rs
+++ b/tests/util_tests.rs
@@ -1,62 +1,56 @@
-use binance::util::*;
+use binance::util::build_request;
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use float_cmp::approx_eq;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::BTreeMap;
-    use std::time::{SystemTime, UNIX_EPOCH};
-    use float_cmp::*;
+#[test]
+fn build_request_empty() {
+    let parameters: BTreeMap<String, String> = BTreeMap::new();
+    let result = build_request(parameters);
+    assert!(result.is_empty());
+}
 
-    #[test]
-    fn build_request_empty() {
-        let parameters: BTreeMap<String, String> = BTreeMap::new();
-        let result = build_request(parameters);
-        assert!(result.is_empty());
-    }
+#[test]
+fn build_request_not_empty() {
+    let mut parameters: BTreeMap<String, String> = BTreeMap::new();
+    parameters.insert("recvWindow".into(), "1234".to_string());
+    let result = build_request(parameters);
+    assert_eq!(result, format!("recvWindow={}", 1234));
+}
 
-    #[test]
-    fn build_request_not_empty() {
-        let mut parameters: BTreeMap<String, String> = BTreeMap::new();
-        parameters.insert("recvWindow".into(), "1234".to_string());
-        let result = build_request(parameters);
-        assert_eq!(result, format!("recvWindow={}", 1234));
-    }
+#[test]
+fn build_signed_request() {
+    let now = SystemTime::now();
+    let recv_window = 1234;
 
-    #[test]
-    fn build_signed_request() {
-        let now = SystemTime::now();
-        let recv_window = 1234;
+    let since_epoch = now.duration_since(UNIX_EPOCH).unwrap();
+    let timestamp =
+        since_epoch.as_secs() * 1000 + u64::from(since_epoch.subsec_nanos()) / 1_000_000;
 
-        let since_epoch = now.duration_since(UNIX_EPOCH).unwrap();
-        let timestamp =
-            since_epoch.as_secs() * 1000 + u64::from(since_epoch.subsec_nanos()) / 1_000_000;
+    let parameters: BTreeMap<String, String> = BTreeMap::new();
+    let result = binance::util::build_signed_request_custom(parameters, recv_window, now).unwrap();
 
-        let parameters: BTreeMap<String, String> = BTreeMap::new();
-        let result =
-            binance::util::build_signed_request_custom(parameters, recv_window, now).unwrap();
+    assert_eq!(
+        result,
+        format!("recvWindow={}&timestamp={}", recv_window, timestamp)
+    );
+}
 
-        assert_eq!(
-            result,
-            format!("recvWindow={}&timestamp={}", recv_window, timestamp)
-        );
-    }
+#[test]
+fn to_i64() {
+    let value_max = serde_json::json!(i64::MAX);
+    let value_min = serde_json::json!(i64::MIN);
+    assert_eq!(binance::util::to_i64(&value_max), i64::MAX);
+    assert_eq!(binance::util::to_i64(&value_min), i64::MIN);
+}
 
-    #[test]
-    fn to_i64() {
-        let value_max = serde_json::json!(i64::MAX);
-        let value_min = serde_json::json!(i64::MIN);
-        assert_eq!(binance::util::to_i64(&value_max), i64::MAX);
-        assert_eq!(binance::util::to_i64(&value_min), i64::MIN);
-    }
-
-    #[test]
-    fn to_f64() {
-        let value = serde_json::json!("123.3");
-        assert!(approx_eq!(
-            f64,
-            binance::util::to_f64(&value),
-            123.3,
-            ulps = 2
-        ));
-    }
+#[test]
+fn to_f64() {
+    let value = serde_json::json!("123.3");
+    assert!(approx_eq!(
+        f64,
+        binance::util::to_f64(&value),
+        123.3,
+        ulps = 2
+    ));
 }


### PR DESCRIPTION
deglob import statements.

I've also removed one level of unnecessary `#[cfg(test)]` nesting in the integration tests, which unfortunately has made the diff a little hard to parse.