### PR TITLE
Some minor fixes: default wss endpoint, dependencies upgrade and futures general endpoint ping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,21 @@ path = "src/lib.rs"
 hex = "0.4"
 hmac = "0.12.1"
 sha2 = "0.10.6"
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.174", features = ["derive"] }
 serde_json = "1.0"
 error-chain = { version = "0.12.4", default-features = false }
-reqwest = { version = "0.11.4", features = ["blocking", "json"] }
-tungstenite = { version = "0.18.0", features = ["native-tls"] }
-url = "2.2.2"
+reqwest = { version = "0.11.8", features = ["blocking", "json"] }
+tungstenite = { version = "0.19.0", features = ["native-tls"] }
+url = "2.4.0"
 
 [features]
 vendored-tls = ["reqwest/native-tls-vendored", "tungstenite/native-tls-vendored"]
 
 [dev-dependencies]
-csv ="1.1.6"
-mockito = "0.31.0"
-env_logger = "0.9.0"
-criterion = "0.3"
+csv ="1.2.2"
+mockito = "1.1.0"
+env_logger = "0.10.0"
+criterion = "0.5"
 float-cmp = "0.9.0"
 serde_json = "1.0"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             rest_api_endpoint: "https://api.binance.com".into(),
-            ws_endpoint: "wss://stream.binance.com:9443/ws".into(),
+            ws_endpoint: "wss://stream.binance.com/ws".into(),
 
             futures_rest_api_endpoint: "https://fapi.binance.com".into(),
             futures_ws_endpoint: "wss://fstream.binance.com/ws".into(),

--- a/src/futures/general.rs
+++ b/src/futures/general.rs
@@ -1,5 +1,6 @@
 use error_chain::bail;
 
+use crate::model::Empty;
 use crate::futures::model::{ExchangeInformation, ServerTime, Symbol};
 use crate::client::Client;
 use crate::errors::Result;
@@ -14,7 +15,7 @@ pub struct FuturesGeneral {
 impl FuturesGeneral {
     // Test connectivity
     pub fn ping(&self) -> Result<String> {
-        self.client.get(API::Futures(Futures::Ping), None)?;
+        self.client.get::<Empty>(API::Futures(Futures::Ping), None)?;
         Ok("pong".into())
     }
 

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -25,9 +25,9 @@ enum WebsocketAPI {
 impl WebsocketAPI {
     fn params(self, subscription: &str) -> String {
         match self {
-            WebsocketAPI::Default => format!("wss://stream.binance.com:9443/ws/{}", subscription),
+            WebsocketAPI::Default => format!("wss://stream.binance.com/ws/{}", subscription),
             WebsocketAPI::MultiStream => format!(
-                "wss://stream.binance.com:9443/stream?streams={}",
+                "wss://stream.binance.com/stream?streams={}",
                 subscription
             ),
             WebsocketAPI::Custom(url) => format!("{}/{}", url, subscription),

--- a/tests/account_tests.rs
+++ b/tests/account_tests.rs
@@ -6,12 +6,13 @@ use binance::model::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockito::{mock, Matcher};
+    use mockito::{Server, Matcher};
     use float_cmp::*;
 
     #[test]
     fn get_account() {
-        let mock_get_account = mock("GET", "/api/v3/account")
+        let mut server = Server::new();
+        let mock_get_account = server.mock("GET", "/api/v3/account")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "recvWindow=1234&timestamp=\\d+&signature=.*".into(),
@@ -20,7 +21,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -51,7 +52,8 @@ mod tests {
 
     #[test]
     fn get_balance() {
-        let mock_get_account = mock("GET", "/api/v3/account")
+        let mut server = Server::new();
+        let mock_get_account = server.mock("GET", "/api/v3/account")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "recvWindow=1234&timestamp=\\d+&signature=.*".into(),
@@ -60,7 +62,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -75,7 +77,8 @@ mod tests {
 
     #[test]
     fn get_open_orders() {
-        let mock_open_orders = mock("GET", "/api/v3/openOrders")
+        let mut server = Server::new();
+        let mock_open_orders = server.mock("GET", "/api/v3/openOrders")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "recvWindow=1234&symbol=LTCBTC&timestamp=\\d+".into(),
@@ -84,7 +87,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -117,14 +120,15 @@ mod tests {
 
     #[test]
     fn get_all_open_orders() {
-        let mock_open_orders = mock("GET", "/api/v3/openOrders")
+        let mut server = Server::new();
+        let mock_open_orders = server.mock("GET", "/api/v3/openOrders")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("recvWindow=1234&timestamp=\\d+".into()))
             .with_body_from_file("tests/mocks/account/get_open_orders.json")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -157,7 +161,8 @@ mod tests {
 
     #[test]
     fn cancel_all_open_orders() {
-        let mock_cancel_all_open_orders = mock("DELETE", "/api/v3/openOrders")
+        let mut server = Server::new();
+        let mock_cancel_all_open_orders = server.mock("DELETE", "/api/v3/openOrders")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
@@ -166,7 +171,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -203,7 +208,8 @@ mod tests {
 
     #[test]
     fn order_status() {
-        let mock_order_status = mock("GET", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_order_status = server.mock("GET", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "orderId=1&recvWindow=1234&symbol=LTCBTC&timestamp=\\d+".into(),
@@ -212,7 +218,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -242,7 +248,8 @@ mod tests {
 
     #[test]
     fn test_order_status() {
-        let mock_test_order_status = mock("GET", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_order_status = server.mock("GET", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "orderId=1&recvWindow=1234&symbol=LTCBTC&timestamp=\\d+".into(),
@@ -251,7 +258,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -262,14 +269,15 @@ mod tests {
 
     #[test]
     fn limit_buy() {
-        let mock_limit_buy = mock("POST", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_limit_buy = server.mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=LIMIT".into()))
             .with_body_from_file("tests/mocks/account/limit_buy.json")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -299,14 +307,15 @@ mod tests {
 
     #[test]
     fn test_limit_buy() {
-        let mock_test_limit_buy = mock("POST", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_limit_buy = server.mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=LIMIT".into()))
             .with_body("{}")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -317,14 +326,15 @@ mod tests {
 
     #[test]
     fn limit_sell() {
-        let mock_limit_sell = mock("POST", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_limit_sell = server.mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=LIMIT".into()))
             .with_body_from_file("tests/mocks/account/limit_sell.json")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -354,14 +364,15 @@ mod tests {
 
     #[test]
     fn test_limit_sell() {
-        let mock_test_limit_sell = mock("POST", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_limit_sell = server.mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=LIMIT".into()))
             .with_body("{}")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -372,7 +383,8 @@ mod tests {
 
     #[test]
     fn market_buy() {
-        let mock_market_buy = mock("POST", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_market_buy = server.mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timestamp=\\d+&type=MARKET"
@@ -382,7 +394,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -412,7 +424,8 @@ mod tests {
 
     #[test]
     fn test_market_buy() {
-        let mock_test_market_buy = mock("POST", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_market_buy = server.mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timestamp=\\d+&type=MARKET"
@@ -422,7 +435,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -433,14 +446,15 @@ mod tests {
 
     #[test]
     fn market_buy_using_quote_quantity() {
-        let mock_market_buy_using_quote_quantity = mock("POST", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_market_buy_using_quote_quantity = server.mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("quoteOrderQty=0.002&recvWindow=1234&side=BUY&symbol=BNBBTC&timestamp=\\d+&type=MARKET&signature=.*".into()))
             .with_body_from_file("tests/mocks/account/market_buy_using_quote_quantity.json")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -456,14 +470,15 @@ mod tests {
 
     #[test]
     fn test_market_buy_using_quote_quantity() {
-        let mock_test_market_buy_using_quote_quantity = mock("POST", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_market_buy_using_quote_quantity = server.mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("quoteOrderQty=0.002&recvWindow=1234&side=BUY&symbol=BNBBTC&timestamp=\\d+&type=MARKET&signature=.*".into()))
             .with_body("{}")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -476,7 +491,8 @@ mod tests {
 
     #[test]
     fn market_sell() {
-        let mock_market_sell = mock("POST", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_market_sell = server.mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timestamp=\\d+&type=MARKET"
@@ -486,7 +502,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -516,7 +532,8 @@ mod tests {
 
     #[test]
     fn test_market_sell() {
-        let mock_test_market_sell = mock("POST", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_market_sell = server.mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "quantity=1&recvWindow=1234&side=SELL&symbol=LTCBTC&timestamp=\\d+&type=MARKET"
@@ -526,7 +543,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -537,14 +554,15 @@ mod tests {
 
     #[test]
     fn market_sell_using_quote_quantity() {
-        let mock_market_sell_using_quote_quantity = mock("POST", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_market_sell_using_quote_quantity = server.mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("quoteOrderQty=0.002&recvWindow=1234&side=SELL&symbol=BNBBTC&timestamp=\\d+&type=MARKET&signature=.*".into()))
             .with_body_from_file("tests/mocks/account/market_sell_using_quote_quantity.json")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -560,14 +578,15 @@ mod tests {
 
     #[test]
     fn test_market_sell_using_quote_quantity() {
-        let mock_test_market_sell_using_quote_quantity = mock("POST", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_market_sell_using_quote_quantity = server.mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("quoteOrderQty=0.002&recvWindow=1234&side=SELL&symbol=BNBBTC&timestamp=\\d+&type=MARKET&signature=.*".into()))
             .with_body("{}")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -580,14 +599,15 @@ mod tests {
 
     #[test]
     fn stop_limit_buy_order() {
-        let mock_stop_limit_buy_order = mock("POST", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_stop_limit_buy_order = server.mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&stopPrice=0.09&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=STOP_LOSS_LIMIT".into()))
             .with_body_from_file("tests/mocks/account/stop_limit_buy.json")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -620,14 +640,15 @@ mod tests {
 
     #[test]
     fn test_stop_limit_buy_order() {
-        let mock_test_stop_limit_buy_order = mock("POST", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_stop_limit_buy_order = server.mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&stopPrice=0.09&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=STOP_LOSS_LIMIT".into()))
             .with_body("{}")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -640,14 +661,15 @@ mod tests {
 
     #[test]
     fn stop_limit_sell_order() {
-        let mock_stop_limit_sell_order = mock("POST", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_stop_limit_sell_order = server.mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=SELL&stopPrice=0.09&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=STOP_LOSS_LIMIT".into()))
             .with_body_from_file("tests/mocks/account/stop_limit_sell.json")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -680,14 +702,15 @@ mod tests {
 
     #[test]
     fn test_stop_limit_sell_order() {
-        let mock_test_stop_limit_sell_order = mock("POST", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_stop_limit_sell_order = server.mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=SELL&stopPrice=0.09&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=STOP_LOSS_LIMIT".into()))
             .with_body("{}")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -700,14 +723,15 @@ mod tests {
 
     #[test]
     fn custom_order() {
-        let mock_custom_order = mock("POST", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_custom_order = server.mock("POST", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("newClientOrderId=6gCrw2kRUAF9CvJDGP16IP&price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=MARKET".into()))
             .with_body_from_file("tests/mocks/account/stop_limit_sell.json")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -749,14 +773,15 @@ mod tests {
 
     #[test]
     fn test_custom_order() {
-        let mock_test_custom_order = mock("POST", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_custom_order = server.mock("POST", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("price=0.1&quantity=1&recvWindow=1234&side=BUY&symbol=LTCBTC&timeInForce=GTC&timestamp=\\d+&type=MARKET".into()))
             .with_body("{}")
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -778,7 +803,8 @@ mod tests {
 
     #[test]
     fn cancel_order() {
-        let mock_cancel_order = mock("DELETE", "/api/v3/order")
+        let mut server = Server::new();
+        let mock_cancel_order = server.mock("DELETE", "/api/v3/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "orderId=1&recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
@@ -787,7 +813,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -803,7 +829,8 @@ mod tests {
 
     #[test]
     fn test_cancel_order() {
-        let mock_test_cancel_order = mock("DELETE", "/api/v3/order/test")
+        let mut server = Server::new();
+        let mock_test_cancel_order = server.mock("DELETE", "/api/v3/order/test")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "orderId=1&recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
@@ -812,7 +839,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -823,7 +850,8 @@ mod tests {
 
     #[test]
     fn trade_history() {
-        let mock_trade_history = mock("GET", "/api/v3/myTrades")
+        let mut server = Server::new();
+        let mock_trade_history = server.mock("GET", "/api/v3/myTrades")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+".into(),
@@ -832,7 +860,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_rest_api_endpoint(mockito::server_url())
+            .set_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: Account = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();

--- a/tests/futures_account_tests.rs
+++ b/tests/futures_account_tests.rs
@@ -5,14 +5,15 @@ use binance::futures::account::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockito::{mock, Matcher};
+    use mockito::{Server, Matcher};
     use float_cmp::*;
     use binance::account::OrderSide;
     use binance::futures::model::Transaction;
 
     #[test]
     fn change_initial_leverage() {
-        let mock_change_leverage = mock("POST", "/fapi/v1/leverage")
+        let mut server = Server::new();
+        let mock_change_leverage = server.mock("POST", "/fapi/v1/leverage")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "leverage=2&recvWindow=1234&symbol=LTCUSDT&timestamp=\\d+&signature=.*".into(),
@@ -21,7 +22,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_futures_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: FuturesAccount = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -41,7 +42,8 @@ mod tests {
 
     #[test]
     fn cancel_all_open_orders() {
-        let mock = mock("DELETE", "/fapi/v1/allOpenOrders")
+        let mut server = Server::new();
+        let mock = server.mock("DELETE", "/fapi/v1/allOpenOrders")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "recvWindow=1234&symbol=BTCUSDT&timestamp=\\d+&signature=.*".into(),
@@ -50,7 +52,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_futures_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: FuturesAccount = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -61,7 +63,8 @@ mod tests {
 
     #[test]
     fn change_position_mode() {
-        let mock = mock("POST", "/fapi/v1/positionSide/dual")
+        let mut server = Server::new();
+        let mock = server.mock("POST", "/fapi/v1/positionSide/dual")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "dualSidePosition=true&recvWindow=1234&timestamp=\\d+&signature=.*".into(),
@@ -70,7 +73,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_futures_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: FuturesAccount = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -81,14 +84,15 @@ mod tests {
 
     #[test]
     fn stop_market_close_buy() {
-        let mock_stop_market_close_sell = mock("POST", "/fapi/v1/order")
+        let mut server = Server::new();
+        let mock_stop_market_close_sell = server.mock("POST", "/fapi/v1/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("closePosition=TRUE&recvWindow=1234&side=BUY&stopPrice=10.5&symbol=SRMUSDT&timestamp=\\d+&type=STOP_MARKET".into()))
             .with_body_from_file("tests/mocks/futures/account/stop_market_close_position_buy.json")
             .create();
 
         let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_futures_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: FuturesAccount = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -105,14 +109,15 @@ mod tests {
 
     #[test]
     fn stop_market_close_sell() {
-        let mock_stop_market_close_sell = mock("POST", "/fapi/v1/order")
+        let mut server = Server::new();
+        let mock_stop_market_close_sell = server.mock("POST", "/fapi/v1/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("closePosition=TRUE&recvWindow=1234&side=SELL&stopPrice=7.4&symbol=SRMUSDT&timestamp=\\d+&type=STOP_MARKET".into()))
             .with_body_from_file("tests/mocks/futures/account/stop_market_close_position_sell.json")
             .create();
 
         let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_futures_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: FuturesAccount = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -129,14 +134,15 @@ mod tests {
 
     #[test]
     fn custom_order() {
-        let mock_custom_order = mock("POST", "/fapi/v1/order")
+        let mut server = Server::new();
+        let mock_custom_order = server.mock("POST", "/fapi/v1/order")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("closePosition=TRUE&recvWindow=1234&side=SELL&stopPrice=7.4&symbol=SRMUSDT&timestamp=\\d+&type=STOP_MARKET".into()))
             .with_body_from_file("tests/mocks/futures/account/stop_market_close_position_sell.json")
             .create();
 
         let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_futures_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: FuturesAccount = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();
@@ -169,7 +175,8 @@ mod tests {
 
     #[test]
     fn get_income() {
-        let mock = mock("GET", "/fapi/v1/income")
+        let mut server = Server::new();
+        let mock = server.mock("GET", "/fapi/v1/income")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex(
                 "endTime=12345678910&incomeType=TRANSFER&limit=10\
@@ -180,7 +187,7 @@ mod tests {
             .create();
 
         let config = Config::default()
-            .set_futures_rest_api_endpoint(mockito::server_url())
+            .set_futures_rest_api_endpoint(server.url())
             .set_recv_window(1234);
         let account: FuturesAccount = Binance::new_with_config(None, None, &config);
         let _ = env_logger::try_init();

--- a/tests/futures_general_tests.rs
+++ b/tests/futures_general_tests.rs
@@ -1,0 +1,27 @@
+use binance::api::*;
+use binance::config::*;
+use binance::futures::general::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+
+    #[test]
+    fn ping() {
+        let mut server = Server::new();
+        let mock_ping = server.mock("GET", "/fapi/v1/ping")
+            .with_header("content-type", "application/json;charset=UTF-8")
+            .with_body("{}")
+            .create();
+
+        let config = Config::default().set_futures_rest_api_endpoint(server.url());
+        println!("{}", server.url());
+        let general: FuturesGeneral = Binance::new_with_config(None, None, &config);
+
+        let pong = general.ping().unwrap();
+        mock_ping.assert();
+
+        assert_eq!(pong, "pong");
+    }
+}

--- a/tests/futures_market_test.rs
+++ b/tests/futures_market_test.rs
@@ -6,17 +6,18 @@ use binance::futures::model::OpenInterestHist;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockito::{mock, Matcher};
+    use mockito::{Server, Matcher};
 
     #[test]
     fn open_interest_statistics() {
-        let mock_open_interest_statistics = mock("GET", "/futures/data/openInterestHist")
+        let mut server = Server::new();
+        let mock_open_interest_statistics = server.mock("GET", "/futures/data/openInterestHist")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("limit=10&period=5m&symbol=BTCUSDT".into()))
             .with_body_from_file("tests/mocks/futures/market/open_interest_statistics.json")
             .create();
 
-        let config = Config::default().set_futures_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_futures_rest_api_endpoint(server.url());
         let market: FuturesMarket = Binance::new_with_config(None, None, &config);
 
         let open_interest_hists = market

--- a/tests/general_tests.rs
+++ b/tests/general_tests.rs
@@ -6,17 +6,18 @@ use binance::model::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockito::mock;
+    use mockito::Server;
     use float_cmp::*;
 
     #[test]
     fn ping() {
-        let mock_ping = mock("GET", "/api/v3/ping")
+        let mut server = Server::new();
+        let mock_ping = server.mock("GET", "/api/v3/ping")
             .with_header("content-type", "application/json;charset=UTF-8")
             .with_body("{}")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let general: General = Binance::new_with_config(None, None, &config);
 
         let pong = general.ping().unwrap();
@@ -27,12 +28,13 @@ mod tests {
 
     #[test]
     fn get_server_time() {
-        let mock_server_time = mock("GET", "/api/v3/time")
+        let mut server = Server::new();
+        let mock_server_time = server.mock("GET", "/api/v3/time")
             .with_header("content-type", "application/json;charset=UTF-8")
             .with_body_from_file("tests/mocks/general/server_time.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let general: General = Binance::new_with_config(None, None, &config);
 
         let server_time = general.get_server_time().unwrap();
@@ -43,12 +45,13 @@ mod tests {
 
     #[test]
     fn exchange_info() {
-        let mock_exchange_info = mock("GET", "/api/v3/exchangeInfo")
+        let mut server = Server::new();
+        let mock_exchange_info = server.mock("GET", "/api/v3/exchangeInfo")
             .with_header("content-type", "application/json;charset=UTF-8")
             .with_body_from_file("tests/mocks/general/exchange_info.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let general: General = Binance::new_with_config(None, None, &config);
 
         let exchange_info = general.exchange_info().unwrap();
@@ -59,12 +62,13 @@ mod tests {
 
     #[test]
     fn get_symbol_info() {
-        let mock_exchange_info = mock("GET", "/api/v3/exchangeInfo")
+        let mut server = Server::new();
+        let mock_exchange_info = server.mock("GET", "/api/v3/exchangeInfo")
             .with_header("content-type", "application/json;charset=UTF-8")
             .with_body_from_file("tests/mocks/general/exchange_info.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let general: General = Binance::new_with_config(None, None, &config);
 
         let symbol = general.get_symbol_info("BNBBTC").unwrap();

--- a/tests/market_tests.rs
+++ b/tests/market_tests.rs
@@ -6,18 +6,19 @@ use binance::model::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mockito::{mock, Matcher};
+    use mockito::{Server, Matcher};
     use float_cmp::*;
 
     #[test]
     fn get_depth() {
-        let mock_get_depth = mock("GET", "/api/v3/depth")
+        let mut server = Server::new();
+        let mock_get_depth = server.mock("GET", "/api/v3/depth")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("symbol=LTCBTC".into()))
             .with_body_from_file("tests/mocks/market/get_depth.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let order_book = market.get_depth("LTCBTC").unwrap();
@@ -29,13 +30,14 @@ mod tests {
 
     #[test]
     fn get_custom_depth() {
-        let mock_get_custom_depth = mock("GET", "/api/v3/depth")
+        let mut server = Server::new();
+        let mock_get_custom_depth = server.mock("GET", "/api/v3/depth")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("limit=10&symbol=LTCBTC".into()))
             .with_body_from_file("tests/mocks/market/get_depth.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let order_book = market.get_custom_depth("LTCBTC", 10).unwrap();
@@ -47,12 +49,13 @@ mod tests {
 
     #[test]
     fn get_all_prices() {
-        let mock_get_all_prices = mock("GET", "/api/v3/ticker/price")
+        let mut server = Server::new();
+        let mock_get_all_prices = server.mock("GET", "/api/v3/ticker/price")
             .with_header("content-type", "application/json;charset=UTF-8")
             .with_body_from_file("tests/mocks/market/get_all_prices.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let prices: Prices = market.get_all_prices().unwrap();
@@ -73,13 +76,14 @@ mod tests {
 
     #[test]
     fn get_price() {
-        let mock_get_price = mock("GET", "/api/v3/ticker/price")
+        let mut server = Server::new();
+        let mock_get_price = server.mock("GET", "/api/v3/ticker/price")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("symbol=LTCBTC".into()))
             .with_body_from_file("tests/mocks/market/get_price.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let symbol = market.get_price("LTCBTC").unwrap();
@@ -91,13 +95,14 @@ mod tests {
 
     #[test]
     fn get_average_price() {
-        let mock_get_average_price = mock("GET", "/api/v3/avgPrice")
+        let mut server = Server::new();
+        let mock_get_average_price = server.mock("GET", "/api/v3/avgPrice")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("symbol=LTCBTC".into()))
             .with_body_from_file("tests/mocks/market/get_average_price.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let symbol = market.get_average_price("LTCBTC").unwrap();
@@ -109,12 +114,13 @@ mod tests {
 
     #[test]
     fn get_all_book_tickers() {
-        let mock_get_all_book_tickers = mock("GET", "/api/v3/ticker/bookTicker")
+        let mut server = Server::new();
+        let mock_get_all_book_tickers = server.mock("GET", "/api/v3/ticker/bookTicker")
             .with_header("content-type", "application/json;charset=UTF-8")
             .with_body_from_file("tests/mocks/market/get_all_book_tickers.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let book_tickers = market.get_all_book_tickers().unwrap();
@@ -171,13 +177,14 @@ mod tests {
 
     #[test]
     fn get_book_ticker() {
-        let mock_get_book_ticker = mock("GET", "/api/v3/ticker/bookTicker")
+        let mut server = Server::new();
+        let mock_get_book_ticker = server.mock("GET", "/api/v3/ticker/bookTicker")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("symbol=LTCBTC".into()))
             .with_body_from_file("tests/mocks/market/get_book_ticker.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let book_ticker = market.get_book_ticker("LTCBTC").unwrap();
@@ -192,13 +199,14 @@ mod tests {
 
     #[test]
     fn get_24h_price_stats() {
-        let mock_get_24h_price_stats = mock("GET", "/api/v3/ticker/24hr")
+        let mut server = Server::new();
+        let mock_get_24h_price_stats = server.mock("GET", "/api/v3/ticker/24hr")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("symbol=BNBBTC".into()))
             .with_body_from_file("tests/mocks/market/get_24h_price_stats.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let price_stats = market.get_24h_price_stats("BNBBTC").unwrap();
@@ -245,12 +253,13 @@ mod tests {
 
     #[test]
     fn get_all_24h_price_stats() {
-        let mock_get_all_24h_price_stats = mock("GET", "/api/v3/ticker/24hr")
+        let mut server = Server::new();
+        let mock_get_all_24h_price_stats = server.mock("GET", "/api/v3/ticker/24hr")
             .with_header("content-type", "application/json;charset=UTF-8")
             .with_body_from_file("tests/mocks/market/get_all_24h_price_stats.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let prices_stats = market.get_all_24h_price_stats().unwrap();
@@ -301,13 +310,14 @@ mod tests {
 
     #[test]
     fn get_klines() {
-        let mock_get_klines = mock("GET", "/api/v3/klines")
+        let mut server = Server::new();
+        let mock_get_klines = server.mock("GET", "/api/v3/klines")
             .with_header("content-type", "application/json;charset=UTF-8")
             .match_query(Matcher::Regex("interval=5m&limit=10&symbol=LTCBTC".into()))
             .with_body_from_file("tests/mocks/market/get_klines.json")
             .create();
 
-        let config = Config::default().set_rest_api_endpoint(mockito::server_url());
+        let config = Config::default().set_rest_api_endpoint(server.url());
         let market: Market = Binance::new_with_config(None, None, &config);
 
         let klines = market.get_klines("LTCBTC", "5m", 10, None, None).unwrap();


### PR DESCRIPTION
1. The wss endpoint with 9443 port seems to have issue according to #123. By simply adjusting the default endpoint the problem can be fixed.
2. The mock module has deprecated since mockito 1.0.0. Upgraded the dependencies and affected test module. Some other dependencies are also safely upgraded.
3. FuturesGeneral::ping() doesn't work and since there lacks a test for that, this issue has not been discovered. Added a test module for that and fixed the function.

I'm a Rust beginner and tried my best to make this little contribution.