### PR TITLE
Remove buyer_order_id & seller_order_id from TradeEvent

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -644,12 +644,6 @@ pub struct TradeEvent {
     #[serde(rename = "q")]
     pub qty: String,
 
-    #[serde(rename = "b")]
-    pub buyer_order_id: u64,
-
-    #[serde(rename = "a")]
-    pub seller_order_id: u64,
-
     #[serde(rename = "T")]
     pub trade_order_time: u64,
 


### PR DESCRIPTION
It seems that buyer_order_id & seller_order_id are no longer available in web socket TradeEvent.

https://github.com/binance/binance-spot-api-docs/pull/293/files#diff-f6c5f669d21e2728e696443f36aac96e9054812c89e381667c002f46780b1209

https://developers.binance.com/docs/binance-spot-api-docs/web-socket-streams#trade-streams
