### PR TITLE
Update deps 20241119

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,14 @@ path = "src/lib.rs"
 
 [dependencies]
 hex = "0.4"
-hmac = "0.12.1"
-sha2 = "0.10.8"
-serde = { version = "1.0.197", features = ["derive"] }
+hmac = "0.12"
+sha2 = "0.10"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-error-chain = { version = "0.12.4", default-features = false }
-reqwest = { version = "0.11.24", features = ["blocking", "json"] }
-tungstenite = { version = "0.21.0", features = ["native-tls"] }
-url = "2.5.0"
-clap = "4.5.2"
+error-chain = { version = "0.12", default-features = false }
+reqwest = { version = "0.12", features = ["blocking", "json"] }
+tungstenite = { version = "0.24", features = ["native-tls", "url"] }
+url = "2.5"
 
 [features]
 vendored-tls = [
@@ -38,11 +37,11 @@ vendored-tls = [
 ]
 
 [dev-dependencies]
-csv = "1.3.0"
-mockito = "1.4.0"
-env_logger = "0.11.2"
+csv = "1.3"
+mockito = "1.4"
+env_logger = "0.11"
 criterion = "0.5"
-float-cmp = "0.9.0"
+float-cmp = "0.10"
 serde_json = "1.0"
 
 [[bench]]

--- a/src/account.rs
+++ b/src/account.rs
@@ -760,7 +760,7 @@ impl Account {
             S: Into<String>,
     {
         if !is_start_time_valid(&start_time) {
-            return bail!("Start time should be less than the current time");
+            bail!("Start time should be less than the current time");
         }
 
         let mut parameters: BTreeMap<String, String> = BTreeMap::new();
@@ -777,10 +777,10 @@ impl Account {
             S: Into<String>,
     {
         if end_time <= start_time {
-            return bail!("End time should be greater than start time");
+            bail!("End time should be greater than start time");
         }
         if !is_start_time_valid(&start_time) {
-            return bail!("Start time should be less than the current time");
+            bail!("Start time should be less than the current time");
         }
         self.get_trades(symbol, start_time, end_time)
     }

--- a/src/futures/websockets.rs
+++ b/src/futures/websockets.rs
@@ -194,7 +194,7 @@ impl<'a> FuturesWebSockets<'a> {
     pub fn event_loop(&mut self, running: &AtomicBool) -> Result<()> {
         while running.load(Ordering::Relaxed) {
             if let Some(ref mut socket) = self.socket {
-                let message = socket.0.read_message()?;
+                let message = socket.0.read()?;
                 match message {
                     Message::Text(msg) => {
                         if let Err(e) = self.handle_msg(&msg) {
@@ -202,7 +202,7 @@ impl<'a> FuturesWebSockets<'a> {
                         }
                     }
                     Message::Ping(payload) => {
-                        socket.0.write_message(Message::Pong(payload)).unwrap();
+                        socket.0.send(Message::Pong(payload)).unwrap();
                     }
                     Message::Pong(_) | Message::Binary(_) | Message::Frame(_) => (),
                     Message::Close(e) => bail!(format!("Disconnected {:?}", e)),

--- a/src/util.rs
+++ b/src/util.rs
@@ -48,10 +48,5 @@ fn get_timestamp(start: SystemTime) -> Result<u64> {
 
 pub fn is_start_time_valid(start_time: &u64) -> bool {
     let current_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
-
-    if start_time > &current_time {
-        false
-    } else {
-        true
-    }
+    return start_time <= &current_time;
 }

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -153,7 +153,7 @@ impl<'a> WebSockets<'a> {
     pub fn event_loop(&mut self, running: &AtomicBool) -> Result<()> {
         while running.load(Ordering::Relaxed) {
             if let Some(ref mut socket) = self.socket {
-                let message = socket.0.read_message()?;
+                let message = socket.0.read()?;
                 match message {
                     Message::Text(msg) => {
                         if let Err(e) = self.handle_msg(&msg) {
@@ -161,7 +161,7 @@ impl<'a> WebSockets<'a> {
                         }
                     }
                     Message::Ping(payload) => {
-                        socket.0.write_message(Message::Pong(payload)).unwrap();
+                        socket.0.send(Message::Pong(payload)).unwrap();
                     }
                     Message::Pong(_) | Message::Binary(_) | Message::Frame(_) => (),
                     Message::Close(e) => bail!(format!("Disconnected {:?}", e)),


### PR DESCRIPTION
## Updated deps in `Cargo.toml`

* Removal of `clap` (unused)
* `tungstenite:0.24` has `url` feature which is optional, added since connection uses a parsed `url::Url`
* Other general crate updates

## Tungstenite update

* `read_message` and `write_message` are deprecated and replaced with `read` and `send`, respectively

## General/small fixes
* `error_chain::bail` already expands to `return ..`, and multiple times `return bail!(..)` was called which expands to `return return ..`. Removed unnecessary return
* in `binance::util::is_start_time_valid`, made the if-statement branchless