### PR TITLE
fix(filters): ignore unknown filter variants during deserialization

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -124,6 +124,9 @@ pub enum Filters {
         min_trailing_below_delta: Option<u16>,
         max_trailing_below_delta: Option<u16>,
     },
+    // Add this to catch unknown variants during deserialization
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Binance added a new filter type (`POSITION_RISK_CONTROL`) which isn't recognized by the current enum in the `binance` crate, causing deserialization to fail.

This patch updates the `Filters` enum to use `#[serde(other)]` to ignore unknown variants, preventing panics and improving compatibility with future changes in Binance's API.